### PR TITLE
Fix panda joint 4 upper limit

### DIFF
--- a/moma_gazebo/config/panda_controllers.yaml
+++ b/moma_gazebo/config/panda_controllers.yaml
@@ -61,7 +61,7 @@ joint_space_controller:
     - panda_joint6
     - panda_joint7
   lower_limit: [-2.8973, -1.7628, -2.8973, -3.0718, -2.8973, -0.0175, -2.8973]
-  upper_limit: [2.8973, 1.7628, 2.8973, 0.0698, 2.8973, 3.7525, 2.8973]
+  upper_limit: [2.8973, 1.7628, 2.8973, -0.0698, 2.8973, 3.7525, 2.8973]
   max_velocity: 0.3
   max_acceleration: 0.1
   gain: 1.0

--- a/panda_control/config/controllers.yaml
+++ b/panda_control/config/controllers.yaml
@@ -24,7 +24,7 @@ joint_space_controller:
     - panda_joint6
     - panda_joint7
   lower_limit: [-2.8973, -1.7628, -2.8973, -3.0718, -2.8973, -0.0175, -2.8973]
-  upper_limit: [2.8973, 1.7628, 2.8973, 0.0698, 2.8973, 3.7525, 2.8973]
+  upper_limit: [2.8973, 1.7628, 2.8973, -0.0698, 2.8973, 3.7525, 2.8973]
   max_velocity: 0.3
   max_acceleration: 0.1
   gain: 1.0


### PR DESCRIPTION
This is a small but critical fix, as under certain circumstances, it caused some side-effects and weird controller behavior in simulation that was hard to pin down.