### PR TITLE
Fix joint space controller improper unloading

### DIFF
--- a/moma_controllers/moma_joint_space_controller/src/controller.cpp
+++ b/moma_controllers/moma_joint_space_controller/src/controller.cpp
@@ -253,6 +253,7 @@ void JointSpaceController::read_state() {
 }
 
 void JointSpaceController::cleanup() {
+  trajectory_available_ = false;
   if (sim_) return;
 
   for (size_t i = 0; i < n_joints_; i++) {


### PR DESCRIPTION
This prevents the joint space controller from making the robot immediately go to the previous pose after restarting it.