### PR TITLE
Migrate to `/control` namespace on real robot

### DIFF
--- a/moma_mission/config/state_machine/christmas.yaml
+++ b/moma_mission/config/state_machine/christmas.yaml
@@ -3,7 +3,7 @@
 
 OPEN_GRIPPER:
   default_outcome: None
-  gripper_action_name: /franka_gripper/gripper_action
+  gripper_action_name: /control/franka_gripper/gripper_action
   position: 0.03
   max_effort: 20
   tolerance: 0.001
@@ -11,7 +11,7 @@ OPEN_GRIPPER:
 
 CLOSE_GRIPPER:
   default_outcome: None
-  gripper_action_name: /franka_gripper/gripper_action
+  gripper_action_name: /control/franka_gripper/gripper_action
   position: 0.0
   max_effort: 20
   tolerance: 0.001
@@ -19,7 +19,7 @@ CLOSE_GRIPPER:
 
 OPEN_GRIPPER_FINAL:
   default_outcome: None
-  gripper_action_name: /franka_gripper/gripper_action
+  gripper_action_name: /control/franka_gripper/gripper_action
   position: 0.03
   max_effort: 20
   tolerance: 0.001

--- a/moma_mission/config/state_machine/piloting.yaml
+++ b/moma_mission/config/state_machine/piloting.yaml
@@ -10,7 +10,7 @@ SETUP:
 
 OPEN_GRIPPER:
   default_outcome: Completed
-  gripper_action_name: /franka_gripper/gripper_action
+  gripper_action_name: /control/franka_gripper/gripper_action
   position: 0.03
   max_effort: 20
   tolerance: 0.001
@@ -18,7 +18,7 @@ OPEN_GRIPPER:
 
 CLOSE_GRIPPER:
   default_outcome: Completed
-  gripper_action_name: /franka_gripper/gripper_action
+  gripper_action_name: /control/franka_gripper/gripper_action
   position: 0.0
   max_effort: 20
   tolerance: 0.001

--- a/moma_robot/config/controllers.yaml
+++ b/moma_robot/config/controllers.yaml
@@ -122,7 +122,7 @@ path_admittance_controller:
   type: moma_controllers/PathAdmittanceController
 
   verbose: true
-  wrench_topic: /franka_state_controller/F_ext
+  wrench_topic: /control/franka_state_controller/F_ext
   wrench_opposite: true
   path_in_topic: /desired_path
   path_out_topic: /mpc_reference_path

--- a/moma_robot/launch/robot_pc.launch
+++ b/moma_robot/launch/robot_pc.launch
@@ -14,21 +14,13 @@
   <param name="robot_description" command="$(find xacro)/xacro $(find moma_description)/urdf/superpanda.urdf.xacro use_nominal_extrinsics:=true use_fixed_realsense:=false tool:=$(arg tool)"/>
   <param name="arm_description" command="$(find xacro)/xacro $(find moma_description)/urdf/panda.urdf.xacro use_nominal_extrinsics:=true use_fixed_realsense:=false tool:=$(arg tool)"/>
 
-  <!-- Launch franka gripper -->
-  <include file="$(find franka_gripper)/launch/franka_gripper.launch" if="$(arg load_gripper)">
-	    <arg name="robot_ip" value="$(arg robot_ip)" />
-  </include>
-  
-  <node name="franka_control" pkg="franka_control" type="franka_control_node" output="screen" required="true">
-    <rosparam command="load" file="$(find moma_robot)/config/franka_control_node.yaml" />
-    <param name="robot_ip" value="$(arg robot_ip)" />
-  </node>
-
   <node name="joint_state_publisher" type="joint_state_publisher" pkg="joint_state_publisher" output="screen">
-    <rosparam if="$(arg load_gripper)" param="source_list">[franka_state_controller/joint_states, franka_gripper/joint_states] </rosparam>
-    <rosparam unless="$(arg load_gripper)" param="source_list">[franka_state_controller/joint_states] </rosparam>
+    <rosparam if="$(arg load_gripper)" param="source_list">[control/franka_state_controller/joint_states, control/franka_gripper/joint_states] </rosparam>
+    <rosparam unless="$(arg load_gripper)" param="source_list">[control/franka_state_controller/joint_states] </rosparam>
     <param name="rate" value="30"/>
   </node>
+
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" output="screen"/>
 
   <!-- OCS2 params -->
   <group ns="ocs2_mpc">
@@ -37,11 +29,19 @@
     <param name="base_type" value="$(arg base_type)"/>
   </group>
 
-  <!--<group ns="control">-->
+  <group ns="control">
+      <node name="franka_control" pkg="franka_control" type="franka_control_node" output="screen" required="true">
+        <rosparam command="load" file="$(find moma_robot)/config/franka_control_node.yaml" />
+        <param name="robot_ip" value="$(arg robot_ip)" />
+      </node>
+
+      <!-- Launch franka gripper -->
+      <include file="$(find franka_gripper)/launch/franka_gripper.launch" if="$(arg load_gripper)">
+         <arg name="robot_ip" value="$(arg robot_ip)" />
+      </include>
+
       <rosparam command="load" file="$(find franka_control)/config/default_controllers.yaml" />
       <node name="state_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="franka_state_controller"/>
-
-      <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" output="screen"/>
 
       <!-- Load all available controllers -->
       <rosparam command="load" file="$(find moma_robot)/config/controllers.yaml" />
@@ -57,7 +57,7 @@
       <!-- Already start these controllers -->
       <arg name="controllers_start_list" value="path_passthrough_controller"/>
       <node name="controller_starter" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="$(arg controllers_start_list)" />
-  <!--</group>-->
+  </group>
 
   <node pkg="tf2_ros"
         if="$(eval arg('base_type') == 0)"

--- a/moma_sensor_tools/README.md
+++ b/moma_sensor_tools/README.md
@@ -89,5 +89,5 @@ To show a plot of the raw and filtered wrench applied at the end effector, follo
 - Launch a franka state controller on the real robot (for example `roslaunch moma_robot robot_pc.launch`)
 - Run the wrench filtering: `roslaunch moma_sensor_tools ft_sensor_standalone.launch`
   - Accept to start to previous streaming plugin
-  - Select the topics `/franka_state_controller/F_ext` and `/ft_compensated`
+  - Select the topics `/control/franka_state_controller/F_ext` and `/ft_compensated`
 - Show plots of the wrench in plotjuggler on the operator PC: `roslaunch moma_robot operator_pc.launch plot:=true`

--- a/moma_sensor_tools/config/fext_plotjuggler.xml
+++ b/moma_sensor_tools/config/fext_plotjuggler.xml
@@ -61,21 +61,21 @@
        <plot mode="TimeSeries" style="Lines">
         <range top="6.074721" right="-396.791759" bottom="-24.453614" left="-496.767462"/>
         <limitY/>
-        <curve name="/franka_state_controller/F_ext/wrench/force/x" color="#1f77b4"/>
+        <curve name="/control/franka_state_controller/F_ext/wrench/force/x" color="#1f77b4"/>
        </plot>
       </DockArea>
       <DockArea name="...">
        <plot mode="TimeSeries" style="Lines">
         <range top="5.222191" right="-396.791759" bottom="-22.342221" left="-496.767462"/>
         <limitY/>
-        <curve name="/franka_state_controller/F_ext/wrench/force/y" color="#d62728"/>
+        <curve name="/control/franka_state_controller/F_ext/wrench/force/y" color="#d62728"/>
        </plot>
       </DockArea>
       <DockArea name="...">
        <plot mode="TimeSeries" style="Lines">
         <range top="0.719872" right="-396.791759" bottom="-25.211220" left="-496.767462"/>
         <limitY/>
-        <curve name="/franka_state_controller/F_ext/wrench/force/z" color="#1ac938"/>
+        <curve name="/control/franka_state_controller/F_ext/wrench/force/z" color="#1ac938"/>
        </plot>
       </DockArea>
      </DockSplitter>
@@ -84,21 +84,21 @@
        <plot mode="TimeSeries" style="Lines">
         <range top="2.243591" right="-396.791759" bottom="-1.665965" left="-496.767462"/>
         <limitY/>
-        <curve name="/franka_state_controller/F_ext/wrench/torque/x" color="#1f77b4"/>
+        <curve name="/control/franka_state_controller/F_ext/wrench/torque/x" color="#1f77b4"/>
        </plot>
       </DockArea>
       <DockArea name="...">
        <plot mode="TimeSeries" style="Lines">
         <range top="1.120880" right="-396.791759" bottom="-0.733449" left="-496.767462"/>
         <limitY/>
-        <curve name="/franka_state_controller/F_ext/wrench/torque/y" color="#d62728"/>
+        <curve name="/control/franka_state_controller/F_ext/wrench/torque/y" color="#d62728"/>
        </plot>
       </DockArea>
       <DockArea name="...">
        <plot mode="TimeSeries" style="Lines">
         <range top="2.435035" right="-396.791759" bottom="-2.204999" left="-496.767462"/>
         <limitY/>
-        <curve name="/franka_state_controller/F_ext/wrench/torque/z" color="#1ac938"/>
+        <curve name="/control/franka_state_controller/F_ext/wrench/torque/z" color="#1ac938"/>
        </plot>
       </DockArea>
      </DockSplitter>

--- a/moma_sensor_tools/config/ft_sensor_params.yaml
+++ b/moma_sensor_tools/config/ft_sensor_params.yaml
@@ -2,7 +2,7 @@ has_payload: false
 sensor_frame: panda_EE
 gravity_aligned_frame: world
 calibration_file: $(find moma_sensor_tools)/config/payload_calibration/calibration.yaml
-raw_wrench_topic: /franka_state_controller/F_ext
+raw_wrench_topic: /control/franka_state_controller/F_ext
 out_wrench_topic: /ft_compensated
 estimate_bias_at_startup: true
 filter_constant: 0.05

--- a/moma_sensor_tools/launch/force_sensor_calibration/ft_sensor_calibration.launch
+++ b/moma_sensor_tools/launch/force_sensor_calibration/ft_sensor_calibration.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-    <!-- arg name="wrench_topic" default="/franka_state_controller/F_ext"/ -->
+    <!-- arg name="wrench_topic" default="/control/franka_state_controller/F_ext"/ -->
     <arg name="wrench_topic" default="/rokubimini/ft_sensor0/ft_sensor_readings/wrench"/>
     <arg name="gravity_aligned_frame" default="base_link"/>
     <arg name="debug" default="false"/>


### PR DESCRIPTION
Lowers the barrier between sim and real, as in sim this is already the case.