### PR TITLE
[WIP, Debug] Attempt to make base type in MPC reconfigurable

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -106,6 +106,7 @@ sudo apt-get install \
 	ros-$ROS_DISTRO-interactive-marker-twist-server \
   ros-$ROS_DISTRO-plotjuggler-ros \
   ros-$ROS_DISTRO-jsk-rviz-plugins \
+  ros-$ROS_DISTRO-map-server \
 	qtbase5-dev -y || fail "Error installing system dependencies"
 }
 

--- a/moma_controllers/moma_ocs2/config/mpc/task_panda.info
+++ b/moma_controllers/moma_ocs2/config/mpc/task_panda.info
@@ -1,7 +1,8 @@
 model_settings
 {
-  useCaching                    true
-  recompileLibraries            true
+  useCaching                    false
+  recompileLibraries            false
+  usePreComputation            false
 }
 
 ; DDP settings
@@ -15,8 +16,10 @@ ddp
   minRelCost                    0.1
   constraintTolerance           1e-3
 
-  displayInfo                   false
-  displayShortSummary           false
+  displayInfo                   true
+  displayShortSummary           true
+  debugPrintRollout           true
+  debugCaching           true
   checkNumericalStability       false
 
   AbsTolODE                     1e-5
@@ -67,8 +70,8 @@ mpc
   initMaxStepLength              1.0
   initMinStepLength              1e-2
 
-  debugPrint                     false
-  coldStart                      false
+  debugPrint                     true
+  coldStart                      true
 
   useParallelRiccatiSolver       true  ; use disjoint riccati solver in MP case and recedingHorizon fashion
 

--- a/moma_controllers/moma_ocs2/include/moma_ocs2/MobileManipulatorInterface.h
+++ b/moma_controllers/moma_ocs2/include/moma_ocs2/MobileManipulatorInterface.h
@@ -64,7 +64,7 @@ class MobileManipulatorInterface final : public RobotInterface {
    * @param [in] libraryFolder: The absolute path to the directory to generate CppAD library into.
    * @param [in] urdfXML: The URDF description string for the robot.
    */
-  explicit MobileManipulatorInterface(const std::string& taskFile, const std::string& urdfXML, const size_t armInputDim, const BaseType& baseType);
+  explicit MobileManipulatorInterface(const std::string& taskFile, const std::string& urdfXML, const size_t armInputDim, const BaseType baseType);
 
   const vector_t& getInitialState() { return initialState_; }
 
@@ -85,7 +85,7 @@ class MobileManipulatorInterface final : public RobotInterface {
   const PinocchioInterface& getPinocchioInterface() const { return *pinocchioInterfacePtr_; }
   PinocchioInterface& getPinocchioDesiredInterface() { return *pinocchioDesiredInterfacePtr_; }
 
-  inline const std::string& getEEFrame() { return eeFrame_; }
+  inline const std::string& getEEFrame() const { return eeFrame_; }
 
   /** MobileManipulator PinocchioInterface factory */
   static PinocchioInterface buildPinocchioInterface(const std::string& urdfPath);

--- a/moma_controllers/moma_ocs2/include/moma_ocs2/MobileManipulatorPinocchioMapping.h
+++ b/moma_controllers/moma_ocs2/include/moma_ocs2/MobileManipulatorPinocchioMapping.h
@@ -57,6 +57,7 @@ class MobileManipulatorPinocchioMapping final : public PinocchioStateInputMappin
     typename vector_t::Scalar vx;      // forward velocity in base frame
     typename vector_t::Scalar vy;      // sideways velocity in base frame
     typename vector_t::Scalar vtheta;  // angular velocity
+    std::cout << "MobileManipulatorPinocchioMapping1 base_type" << (int)baseType_ << std::endl;
     switch(baseType_) {
       case BaseType::holonomic:
         vx = input(0);
@@ -82,6 +83,7 @@ class MobileManipulatorPinocchioMapping final : public PinocchioStateInputMappin
     matrix_t dfdu(Jv.rows(), INPUT_DIM(armInputDim_));
     Eigen::Matrix<SCALAR, 3, 3> dvdu_base;
     const SCALAR theta = state(2);
+    std::cout << "MobileManipulatorPinocchioMapping2 base_type" << (int)baseType_ << std::endl;
     switch(baseType_) {
       case BaseType::holonomic:
         // clang-format off
@@ -98,7 +100,10 @@ class MobileManipulatorPinocchioMapping final : public PinocchioStateInputMappin
       case BaseType::none:
       default:
         // clang-format off
-        dvdu_base.setZero();
+        dvdu_base << theta * 0.0, 0.0, 0.0,
+                     0.0, 0.0, 0.0,
+                     0.0, 0.0, 0.0;
+        break;
     }
 
     // clang-format on

--- a/moma_controllers/moma_ocs2/src/MobileManipulatorInterface.cpp
+++ b/moma_controllers/moma_ocs2/src/MobileManipulatorInterface.cpp
@@ -73,7 +73,7 @@ namespace mobile_manipulator {
 /******************************************************************************************************/
 /******************************************************************************************************/
 /******************************************************************************************************/
-MobileManipulatorInterface::MobileManipulatorInterface(const std::string& taskFile, const std::string& urdfXML, const size_t armInputDim, const BaseType& baseType) {
+MobileManipulatorInterface::MobileManipulatorInterface(const std::string& taskFile, const std::string& urdfXML, const size_t armInputDim, const BaseType baseType) {
     // check that task file exists
   boost::filesystem::path taskFilePath(taskFile);
   if (boost::filesystem::exists(taskFilePath)) {
@@ -264,14 +264,14 @@ std::unique_ptr<StateCost> MobileManipulatorInterface::getSelfCollisionConstrain
   std::cerr << "SelfCollision: Testing for " << numCollisionPairs << " collision pairs\n";
 
   std::unique_ptr<StateConstraint> constraint;
-  if (usePreComputation) {
+  //if (usePreComputation) {
     constraint = std::unique_ptr<StateConstraint>(new MobileManipulatorSelfCollisionConstraint(
         MobileManipulatorPinocchioMapping<scalar_t>(armInputDim_, baseType_), std::move(geometryInterface), minimumDistance));
-  } else {
+  /*} else {
     constraint = std::unique_ptr<StateConstraint>(
         new SelfCollisionConstraintCppAd(pinocchioInterface, MobileManipulatorPinocchioMapping<scalar_t>(armInputDim_, baseType_), std::move(geometryInterface),
                                          minimumDistance, "self_collision", libraryFolder, recompileLibraries, false));
-  }
+  }*/
 
   std::unique_ptr<PenaltyBase> penalty(new RelaxedBarrierPenalty({mu, delta}));
 

--- a/moma_controllers/moma_ocs2/src/dynamics/MobileManipulatorDynamics.cpp
+++ b/moma_controllers/moma_ocs2/src/dynamics/MobileManipulatorDynamics.cpp
@@ -64,6 +64,7 @@ ad_vector_t MobileManipulatorDynamics::systemFlowMap(ad_scalar_t time, const ad_
       vx = typename ad_vector_t::Scalar(0.0);
       vy = typename ad_vector_t::Scalar(0.0);
       vtheta = typename ad_vector_t::Scalar(0.0);
+      break;
   }
   dxdt << cos(theta) * vx - sin(theta) * vy, sin(theta) * vx + cos(theta) * vy, vtheta, input.tail(armInputDim_);
   return dxdt;

--- a/moma_controllers/moma_ocs2_ros/CMakeLists.txt
+++ b/moma_controllers/moma_ocs2_ros/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10)
 project(moma_ocs2_ros)
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_BUILD_TYPE Debug)
+
 find_package(Eigen3 3.3 REQUIRED)
 
 set(PROJECT_DEPENDENCIES

--- a/moma_controllers/panda_mpc/CMakeLists.txt
+++ b/moma_controllers/panda_mpc/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.0.2)
 project(panda_mpc)
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_BUILD_TYPE Debug)
+
 find_package(Eigen3 REQUIRED 3.3)
 find_package(Franka 0.7.0 REQUIRED)
 find_package(orocos_kdl)

--- a/moma_demos/piloting_demo/README.md
+++ b/moma_demos/piloting_demo/README.md
@@ -160,7 +160,7 @@ You can use the `2D Pose Estimate` button in RViz to provide ICP with a pose gue
 
 ![alt text](docs/images/icp_pose_estimate.png)
 ```
-roslaunch piloting_demo navigation.launch sim:=[true/false]
+roslaunch piloting_demo navigation.launch sim:=[true/false] use_global_map:=[true/false]
 ```
 
 The static map is loaded and should also be visualized in RViz (purple costamp in the previous image). The costmap is retrieved from the `map_server`. This is loading the map from a `*.yaml` and `*.pgm` files stored at the output directory of step 3 in the [mapping section](#mapping). As long as the static costmap is generated from the same point cloud used for localization, these will align and allow to set a global goal for the path planner. 
@@ -196,7 +196,7 @@ mon launch moma_robot robot_pc_smb.launch
 ```
 In Terminal 3 (__smb_pc__)
 ```
-mon luanch piloting_demo navigation.launch sim:=false
+mon luanch piloting_demo navigation.launch sim:=false use_global_map:=[true/false]
 ```
 In Terminal 4 (__operator_pc__)
 ```

--- a/moma_demos/piloting_demo/launch/mission.launch
+++ b/moma_demos/piloting_demo/launch/mission.launch
@@ -7,7 +7,7 @@
     <!-- param name="z" value="0"/-->
   </include>
 
-  <!-- detection hotspot -->
+  <!-- detection hotspot relative to estimated valve pose -->
   <node pkg="tf2_ros"
         type="static_transform_publisher"
         name="hotspot_broadcaster"

--- a/moma_demos/piloting_demo/launch/mission.launch
+++ b/moma_demos/piloting_demo/launch/mission.launch
@@ -1,7 +1,17 @@
 <?xml version="1.0"?>
 <launch>
   <!-- valve model -->
-  <include file="$(find piloting_demo)/launch/valve.launch"/>
+  <include file="$(find piloting_demo)/launch/valve.launch">
+    <!-- param name="x" value="0"/-->
+    <!-- param name="y" value="0"/-->
+    <!-- param name="z" value="0"/-->
+  </include>
+
+  <!-- detection hotspot -->
+  <node pkg="tf2_ros"
+        type="static_transform_publisher"
+        name="hotspot_broadcaster"
+        args="-2 0 0 0 0 0 valve_gt hotspot" />
   
   <!-- mission state machine -->
   <rosparam command="load" file="$(find moma_mission)/config/state_machine/piloting.yaml" subst_value="true"/>

--- a/moma_demos/piloting_demo/launch/navigation.launch
+++ b/moma_demos/piloting_demo/launch/navigation.launch
@@ -9,7 +9,7 @@
     <arg name="odom_topic"        default="/base_odom"/>
 
     <!-- localize agains prebuilt map -->
-    <include file="$(find smb_slam)/launch/localization.launch">
+    <include file="$(find smb_slam)/launch/localization.launch" if="$(arg use_global_map)">
         <arg name="launch_rviz"             value="false"/>
         <arg name="launch_sensors"          value="false"/>
         <arg name="use_lidar_odometry"      value="false"/>
@@ -17,6 +17,8 @@
         <arg name="map_file_name"           value="$(arg map_file_name)"/>
         <arg name="parameter_filepath"      value="$(find piloting_demo)/config/localization/icp_params.yaml"/>
     </include>
+
+    <node pkg="tf2_ros" type="static_transform_publisher" name="map_broadcaster" args="0 0 0 0 0 0 tracking_camera_odom map" unless="$(arg use_global_map)"/>
 
     <!-- Base planner can use a global map and locally replans for obstacle avoidance -->
     <include file="$(find smb_navigation)/launch/navigate2d_ompl.launch">

--- a/moma_demos/piloting_demo/launch/sim.launch
+++ b/moma_demos/piloting_demo/launch/sim.launch
@@ -7,6 +7,7 @@
     <arg name="launch_navigation" default="true"/>
     <arg name="base_type" default="1"/>
     <arg name="world_name" default="$(find piloting_demo)/worlds/schutz.world"/>
+    <arg name="use_global_map" default="true"/>
 
     <!-- Control-->
     <!-- load a arm only description for the arm controllers -->
@@ -70,7 +71,7 @@
     <!-- Localization and Navigation -->
     <include file="$(find piloting_demo)/launch/navigation.launch" if="$(arg launch_navigation)">
         <arg name="sim"               value="true"/>
-        <arg name="use_global_map"    value="true"/>
+        <arg name="use_global_map"    value="$(arg use_global_map)"/>
         <arg name="global_frame"      value="map"/> 
     </include>
 

--- a/moma_demos/piloting_demo/launch/valve.launch
+++ b/moma_demos/piloting_demo/launch/valve.launch
@@ -2,7 +2,7 @@
 <launch>
   <arg name="sim" default="false"/>
 
-  <param name="valve_description" command="$(find xacro)/xacro --inorder $(find piloting_demo)/urdf/valve.urdf.xacro pitch:=0 yaw:=0.0 x:=0.66 y:=0.017 z:=0.426"/>
+  <param name="valve_description" command="$(find xacro)/xacro --inorder $(find piloting_demo)/urdf/valve.urdf.xacro pitch:=0 yaw:=0.0 x:=0.71 y:=0.017 z:=0.426"/>
 
   <node name="spawn_valve" pkg="gazebo_ros" type="spawn_model" args="-param valve_description -urdf -model valve" output="screen" if="$(arg sim)"/>
 

--- a/moma_demos/piloting_demo/launch/valve.launch
+++ b/moma_demos/piloting_demo/launch/valve.launch
@@ -1,8 +1,11 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="sim" default="false"/>
+  <arg name="x"   default="0.71"/>
+  <arg name="y"   default="0.017"/>
+  <arg name="z"   default="0.426"/>
 
-  <param name="valve_description" command="$(find xacro)/xacro --inorder $(find piloting_demo)/urdf/valve.urdf.xacro pitch:=0 yaw:=0.0 x:=0.71 y:=0.017 z:=0.426"/>
+  <param name="valve_description" command="$(find xacro)/xacro $(find piloting_demo)/urdf/valve.urdf.xacro pitch:=0 yaw:=0.0 x:=$(arg x) y:=$(arg y) z:=$(arg z)"/>
 
   <node name="spawn_valve" pkg="gazebo_ros" type="spawn_model" args="-param valve_description -urdf -model valve" output="screen" if="$(arg sim)"/>
 

--- a/moma_mission/config/state_machine/piloting.yaml
+++ b/moma_mission/config/state_machine/piloting.yaml
@@ -92,7 +92,7 @@ OBSERVATION_POSE:
 
 OBSERVATION_APPROACH:
   default_outcome: None
-  duration: 5.0
+  duration: 10.0
   control_frame: tracking_camera_odom
   target_frame: observation
   startlist: ['mpc_controller', 'path_passthrough_controller'] #, 'path_admittance_controller' ]
@@ -134,8 +134,8 @@ APPROACH_VALVE:
 GRASP_VALVE:
   default_outcome: None
   manager_namespace: panda
-  startlist: ['mpc_controller', 'path_passthrough_controller']
-  stoplist: ['joint_space_controller']
+  startlist: ['mpc_controller', 'path_admittance_controller']
+  stoplist: ['joint_space_controller', 'path_passthrough_controller']
 
   poses_topic: /valve_poses
   section: 'first'
@@ -143,8 +143,8 @@ GRASP_VALVE:
 MANIPULATE_VALVE:
   default_outcome: None
   manager_namespace: panda
-  startlist: ['mpc_controller', 'path_passthrough_controller']
-  stoplist: ['joint_space_controller']
+  startlist: ['mpc_controller', 'path_admittance_controller']
+  stoplist: ['joint_space_controller', 'path_passthrough_controller']
 
   poses_topic: /valve_poses
   angular_speed: 0.5
@@ -152,9 +152,11 @@ MANIPULATE_VALVE:
 BACKOFF_VALVE:
   default_outcome: None
   manager_namespace: panda
-  startlist: [ 'mpc_controller', 'path_passthrough_controller' ]
-  stoplist: [ 'joint_space_controller' ]
+  startlist: [ 'mpc_controller', 'path_admittance_controller' ]
+  stoplist: [ 'joint_space_controller', 'path_passthrough_controller' ]
+  duration: 10.0
 
   poses_topic: /valve_poses
   offset: [ 0, 0, -0.1 ]
   section: 'last'
+

--- a/moma_mission/config/state_machine/piloting.yaml
+++ b/moma_mission/config/state_machine/piloting.yaml
@@ -9,7 +9,7 @@ IDLE:
   default_outcome: ExecuteManipulationPlan
 
 OPEN_GRIPPER:
-  default_outcome: None
+  default_outcome: Completed
   gripper_action_name: /panda/franka_gripper/gripper_action
   position: 0.03
   max_effort: 20
@@ -17,7 +17,7 @@ OPEN_GRIPPER:
   timeout: 5.0
 
 CLOSE_GRIPPER:
-  default_outcome: None
+  default_outcome: Completed
   gripper_action_name: /panda/franka_gripper/gripper_action
   position: 0.0
   max_effort: 20
@@ -25,7 +25,7 @@ CLOSE_GRIPPER:
   timeout: 5.0
 
 HOME_ROBOT:
-  default_outcome: None
+  default_outcome: Completed
   action_name: /joint_space_controller_server
   manager_namespace: panda
   startlist: ['joint_space_controller']
@@ -35,7 +35,7 @@ HOME_ROBOT:
 
 # hack to avoid self collision in the end
 HOME_ROBOT_FINAL:
-  default_outcome: None
+  default_outcome: Completed
   action_name: /joint_space_controller_server
   manager_namespace: panda
   startlist: ['joint_space_controller']

--- a/moma_mission/config/state_machine/piloting.yaml
+++ b/moma_mission/config/state_machine/piloting.yaml
@@ -44,16 +44,16 @@ HOME_ROBOT_FINAL:
     - [-0.65, -0.885, 0, -2.1, 0, 1.571, 0]
 
 REACH_DETECTION_HOTSPOT:
-  default_outcome: Completed
+  default_outcome: None
   goal_action_topic: /move_base
-  target_frame: navigation_target
+  target_frame: hotspot
   goal_pose_topic: /move_base_simple/goal
   base_pose_topic: /base_pose_measured
   base_odometry_topic: /base_odom
 
   manager_namespace: smb
   startlist: ['smb_diff_drive']
-  stoplist: []
+  stoplist: ['mpc_controller']
 
   timeout: 10000.0
   tolerance_m: 0.30
@@ -68,7 +68,7 @@ WAYPOINT_FOLLOWING:
 
   manager_namespace: smb
   startlist: ['smb_diff_drive']
-  stoplist: []
+  stoplist: ['mpc_controller']
 
   timeout: 10000.0
   tolerance_m: 0.30

--- a/moma_mission/config/state_machine/piloting.yaml
+++ b/moma_mission/config/state_machine/piloting.yaml
@@ -90,6 +90,15 @@ OBSERVATION_POSE:
   image_fill_ratio: 0.5
   heading: [1, 0, 0]
 
+WHOLE_BODY_MPC:
+  default_outcome: None
+  node: panda/mpc_controller
+  params:
+    base_type: 0
+  startlist: []
+  stoplist: ['mpc_controller']
+  manager_namespace: panda
+
 OBSERVATION_APPROACH:
   default_outcome: None
   duration: 10.0

--- a/moma_mission/demo/piloting.py
+++ b/moma_mission/demo/piloting.py
@@ -6,6 +6,7 @@ import smach_ros
 from moma_mission.core.state_ros import *
 from moma_mission.missions.piloting.states import *
 from moma_mission.missions.piloting.sequences import *
+from moma_mission.states.configuration import DynamicReconfigureState
 from moma_mission.states.observation import FOVSamplerState
 from moma_mission.states.transform_visitor import TransformVisitorState
 from moma_mission.states.path_visitor import PathVisitorState
@@ -66,6 +67,12 @@ try:
         rospy.loginfo("Observation pose")
         state_machine.add('OBSERVATION_POSE',
                           FOVSamplerState,
+                          transitions={'Completed': 'WHOLE_BODY_MPC',
+                                       'Failure': 'Failure'})
+
+        rospy.loginfo("Whole-body MPC")
+        state_machine.add('WHOLE_BODY_MPC',
+                          DynamicReconfigureState,
                           transitions={'Completed': 'OBSERVATION_APPROACH',
                                        'Failure': 'Failure'})
 

--- a/moma_mission/src/moma_mission/missions/piloting/states.py
+++ b/moma_mission/src/moma_mission/missions/piloting/states.py
@@ -325,8 +325,9 @@ class ModelFitValveState(StateRos):
 
     def _model_fit(self, points3d: np.ndarray, frame: str) -> TransformStamped:
         valve: ValveModel
-        resisual, valve = self.valve_fitter.estimate_from_3d_points(points3d, frame, 
+        residual, valve = self.valve_fitter.estimate_from_3d_points(points3d, frame, 
           error_threshold=self.error_threshold)
+        print(f"Fit valve with residual {residual}")
         if valve is None:
             return None
         self.set_context('valve_model', valve)
@@ -398,6 +399,8 @@ class ModelFitValveState(StateRos):
               residual, valve_fit = self.valve_fitter.estimate_from_3d_points(p.T, self.frame_id, 
                                                                     handle_radius=0.01,
                                                                     error_threshold=self.error_threshold)
+              print(f"Residual is {residual}")
+
               # if valve_fit is not None:
               #     points_new.append(p)
               if valve_fit is not None and residual < min_residual:

--- a/moma_mission/src/moma_mission/missions/piloting/states.py
+++ b/moma_mission/src/moma_mission/missions/piloting/states.py
@@ -187,7 +187,7 @@ class NavigationState(SingleNavGoalState):
 
         rospy.loginfo("Reaching goal at {}, {}".format(
             goal.pose.position.x, goal.pose.position.y))
-        success = self.reach_goal(goal)
+        success = self.reach_goal(goal, action=True)
         if not success:
             rospy.logerr("Failed to reach base goal.")
             return 'Failure'

--- a/moma_mission/src/moma_mission/missions/piloting/valve_fitting.py
+++ b/moma_mission/src/moma_mission/missions/piloting/valve_fitting.py
@@ -319,7 +319,7 @@ class ValveFitter:
         else:
             rospy.logerr(
                 "Could not fit the 3d points to a circular valve wheel")
-            return None
+            return np.inf, None
 
     def _non_linear_optimization(self):
 

--- a/moma_mission/src/moma_mission/states/configuration.py
+++ b/moma_mission/src/moma_mission/states/configuration.py
@@ -1,0 +1,23 @@
+import dynamic_reconfigure.client
+
+from moma_mission.core import StateRosControl
+
+
+class DynamicReconfigureState(StateRosControl):
+    def __init__(self, ns):
+        StateRosControl.__init__(self, ns=ns)
+
+        self.client = dynamic_reconfigure.client.Client(self.get_scoped_param("node"))
+
+
+    def run(self):
+        controller_switched = self.do_switch()
+        if not controller_switched:
+            return 'Failure'
+
+        #try:
+        self.client.update_configuration(self.get_scoped_param("params"))
+        #except:
+        #    return 'Failure'
+
+        return 'Completed'

--- a/moma_mission/src/moma_mission/utils/ros.py
+++ b/moma_mission/src/moma_mission/utils/ros.py
@@ -71,7 +71,7 @@ def switch_ros_controller(startlist=[], stoplist=[], manager_namespace=''):
     req = SwitchControllerRequest()
     req.start_controllers = controller_start_list
     req.stop_controllers = controller_stop_list
-    req.timeout = 5.0
+    req.timeout = 5000.0
     req.start_asap = True
     req.strictness = req.STRICT
 

--- a/moma_tools/moma_dashboard/config/dashboard.yaml
+++ b/moma_tools/moma_dashboard/config/dashboard.yaml
@@ -1,13 +1,13 @@
 moma_joint_position_control_gui:
   controller_name: joint_space_controller
-  controller_namespace: control
+  controller_namespace: panda
   states_topic: /joint_states
 
 moma_joint_velocity_control_gui:
   controller_name: joint_velocity_controller
-  controller_namespace: control
+  controller_namespace: panda
 
 moma_joint_states_display_gui:
   # The joint limits and safety margins are read from this controller's parameters
   controller_name: joint_velocity_controller
-  controller_namespace: control
+  controller_namespace: panda

--- a/moma_tools/moma_guis/moma_controller_manager_gui/src/moma_controller_manager_gui/controller_manager.py
+++ b/moma_tools/moma_guis/moma_controller_manager_gui/src/moma_controller_manager_gui/controller_manager.py
@@ -177,6 +177,9 @@ class ControllerManager(Plugin):
             if len(relevant_items) > 0:
                 self._widget.cm_combo.setCurrentIndex(relevant_items[0])
                 self._on_cm_change(self._widget.cm_combo.itemText(relevant_items[0]))
+            else:
+                self._widget.cm_combo.setCurrentIndex(0)
+                self._on_cm_change(self._widget.cm_combo.itemText(0))
 
     def _on_cm_change(self, cm_ns):
         self._cm_ns = cm_ns


### PR DESCRIPTION
This is a debugging branch that changes a lot of things in order to make the MPC controller run in debug mode.
The reason for this is that even though a new instance of `mm_interface_` is created on every start of MPC, the current `base_type` variable has no effect. That is, once a single instance of `mm_interface_` has been created, it is not possible to change the base type anyhow, not even by destroying the instance. The old instance caches and somehow leaks this data into the new instance.
I currently suppose this has to do with internal caching effects of `ocs2`. That's why in this branch, all caching options in the `task_panda.info` file are disabled.
The problem persists anyway.

This PR should NOT be merged as is.