### PR TITLE
Controller cleanup and valve sim fix

### DIFF
--- a/moma_controllers/moma_cartesian_impedance_controller/src/cartesian_impedance_controller.cpp
+++ b/moma_controllers/moma_cartesian_impedance_controller/src/cartesian_impedance_controller.cpp
@@ -63,8 +63,8 @@ bool CartesianImpedanceController::init_params(ros::NodeHandle& node_handle) {
     return false;
   }
 
-  if (!node_handle.getParam("target_frame", target_frame_id_) || target_frame_id_.empty()) {
-    ROS_ERROR_STREAM("Failed to get target_frame or invalid param.");
+  if (!node_handle.getParam("tool_link", target_frame_id_) || target_frame_id_.empty()) {
+    ROS_ERROR_STREAM("Failed to get tool_link or invalid param.");
     return false;
   }
 

--- a/moma_demos/piloting_demo/launch/gazebo.launch
+++ b/moma_demos/piloting_demo/launch/gazebo.launch
@@ -44,10 +44,4 @@
       -J panda_joint6 1.571
       -J panda_joint7 0.785" />
 
-  <!-- Load joint controller to publish the joint state under object namespace -->
-  <group ns="valve">
-    <rosparam command="load" file="$(find piloting_demo)/config/sim/controllers.yaml"/>
-    <node name="valve_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="valve_state_controller" />
-  </group>
-
 </launch>

--- a/moma_demos/piloting_demo/launch/mission.launch
+++ b/moma_demos/piloting_demo/launch/mission.launch
@@ -2,16 +2,6 @@
 <launch>
   <arg name="sim" default="false"/>
 
-  <!-- interactive marker -->
-  <node pkg="moma_cartesian_impedance_controller" type="interactive_marker.py" name="interactive_marker" output="screen">
-    <param name="base_frame" value="panda_link0"/>
-    <param name="target_frame" value="panda_hand"/>
-    <param name="topic_name" value="/panda/cartesian_impedance_controller/equilibrium_pose"/>
-  </node>
-
-  <!-- set the correct internal ee frame -->
-  <node pkg="moma_cartesian_impedance_controller" type="set_EE_frame.py" name="set_EE_frame_node" output="screen" respawn="true"/>
-
   <!-- Load joint controller to publish the joint state under object namespace -->
   <group ns="valve" if="$(arg sim)">
     <rosparam command="load" file="$(find piloting_demo)/config/sim/controllers.yaml"/>

--- a/moma_demos/piloting_demo/launch/mission.launch
+++ b/moma_demos/piloting_demo/launch/mission.launch
@@ -12,6 +12,12 @@
   <!-- set the correct internal ee frame -->
   <node pkg="moma_cartesian_impedance_controller" type="set_EE_frame.py" name="set_EE_frame_node" output="screen" respawn="true"/>
 
+  <!-- Load joint controller to publish the joint state under object namespace -->
+  <group ns="valve" if="$(arg sim)">
+    <rosparam command="load" file="$(find piloting_demo)/config/sim/controllers.yaml"/>
+    <node name="valve_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="valve_state_controller" />
+  </group>
+
   <!-- valve model -->
   <include file="$(find piloting_demo)/launch/valve.launch">
     <arg name="sim" value="true"/>

--- a/moma_demos/piloting_demo/launch/mission.launch
+++ b/moma_demos/piloting_demo/launch/mission.launch
@@ -20,7 +20,7 @@
 
   <!-- valve model -->
   <include file="$(find piloting_demo)/launch/valve.launch">
-    <arg name="sim" value="true"/>
+    <arg name="sim" value="$(arg sim)"/>
     <arg name="x" value="2.5"/>
     <arg name="y" value="2.5"/>
     <!-- arg name="z" value="0"/-->

--- a/moma_demos/piloting_demo/launch/operator.launch
+++ b/moma_demos/piloting_demo/launch/operator.launch
@@ -14,7 +14,7 @@
     <param name="server_name"   value="cartesian_impedance_interactive_target"/>
     <param name="mode"          value="pose"/>
     <param name="base_frame"    value="panda_link0"/>
-    <param name="target_frame"  value="tool_frame"/>
+    <param name="tool_link"     value="tool_frame"/>
     <param name="topic_name"    value="/panda/cartesian_impedance_controller/equilibrium_pose"/>
   </node>
 
@@ -24,7 +24,7 @@
     <param name="server_name"   value="mpc_interactive_target"/>
     <param name="mode"          value="path"/>
     <param name="base_frame"    value="tracking_camera_odom"/>
-    <param name="target_frame"  value="tool_frame"/>
+    <param name="tool_link"     value="tool_frame"/>
     <param name="topic_name"    value="/desired_path"/>
   </node>
 

--- a/moma_demos/piloting_demo/launch/sim.launch
+++ b/moma_demos/piloting_demo/launch/sim.launch
@@ -20,13 +20,6 @@
     </group>
 
     <group ns="panda">
-        <group ns="mpc_controller">
-          <param name="task_file" value="$(find moma_ocs2)/config/mpc/task_panda.info"/>
-        </group>
-        <group ns="mpc_wholebody_controller">
-          <param name="task_file" value="$(find moma_ocs2)/config/mpc/task_panda_wholebody.info"/>
-        </group>
-
         <group if="$(eval arg('tool') == 'panda_hand')">
             <node name="gripper_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="franka_gripper" />
         </group>
@@ -36,7 +29,7 @@
         </group>
 
         <!-- start joint position trajectory controller -->
-        <rosparam file="$(find moma_gazebo)/config/panda_controllers.yaml" command="load" />
+        <rosparam file="$(find moma_gazebo)/config/panda_controllers.yaml" command="load" subst_value="true"/>
         <rosparam file="$(find moma_gazebo)/config/gripper_controllers.yaml" command="load" />
 
         <node name="arm_start_controller_spawner"

--- a/moma_demos/piloting_demo/launch/sim.launch
+++ b/moma_demos/piloting_demo/launch/sim.launch
@@ -39,8 +39,14 @@
         <node name="arm_stop_controller_spawner"
               pkg="controller_manager"
               type="spawner"
-              output="screen" args="--stopped mpc_controller mpc_wholebody_controller joint_space_controller path_passthrough_controller path_admittance_controller"
+              output="screen" args="--stopped mpc_controller mpc_wholebody_controller cartesian_impedance_controller joint_space_controller path_passthrough_controller path_admittance_controller"
               launch-prefix="bash -c 'sleep 12; $0 $@' " />
+
+        <!-- Allow to use the grasp action as on the real robot -->
+        <node pkg="moma_gazebo" type="grasp_action_relay.py" name="grasp_action_relay" output="screen">
+            <param name="in_action_name" value="franka_gripper/grasp"/>
+            <param name="out_action_name" value="franka_gripper/gripper_action"/>
+        </node>
     </group>
 
     <!-- Joint the readings published by Smb and Panda -->
@@ -103,6 +109,6 @@
 
   <!-- try cleaner start waiting some time before unpausing -->
   <node name="unpause_gazebo" pkg="moma_gazebo" type="unpause_gazebo.py">
-      <param name="wait_before_unpause" value="8.0"/>
+      <param name="wait_before_unpause" value="5.0"/>
   </node>
 </launch>

--- a/moma_gazebo/config/panda_controllers.yaml
+++ b/moma_gazebo/config/panda_controllers.yaml
@@ -125,6 +125,7 @@ mpc_controller:
   arm_id: panda
 
   robot_name: "panda"
+  task_file: "$(find moma_ocs2)/config/mpc/task_panda.info"
   base_type: 0
   base_link: "tracking_camera_odom"
   tool_link: "tool_frame"
@@ -164,6 +165,7 @@ mpc_wholebody_controller:
   arm_id: panda
 
   robot_name: "panda"
+  task_file: "$(find moma_ocs2)/config/mpc/task_panda_wholebody.info"
   base_type: 1
   base_link: "tracking_camera_odom"
   tool_link: "tool_frame"

--- a/moma_gazebo/config/panda_controllers.yaml
+++ b/moma_gazebo/config/panda_controllers.yaml
@@ -225,7 +225,7 @@ path_admittance_controller:
 cartesian_impedance_controller:
   type: moma_controllers/CartesianImpedanceController
   arm_id: panda
-  target_frame: tool_frame
+  tool_link: tool_frame
   joint_names:
     - panda_joint1
     - panda_joint2

--- a/moma_gazebo/scripts/grasp_action_relay.py
+++ b/moma_gazebo/scripts/grasp_action_relay.py
@@ -1,0 +1,46 @@
+#! /usr/bin/env python
+import rospy
+from actionlib.simple_action_client import SimpleActionClient
+from actionlib.simple_action_server import SimpleActionServer
+
+from franka_gripper.msg import GraspAction, GraspGoal, GraspResult
+from control_msgs.msg import GripperCommandAction, GripperCommandGoal
+
+class GraspRelay:
+    def __init__(self) -> None:
+        self.in_action_name = rospy.get_param("~in_action_name")
+        self.out_action_name = rospy.get_param("~out_action_name")
+
+        self.grasp_server = SimpleActionServer(self.in_action_name, GraspAction, self.relay_action, auto_start=False)
+        self.gripper_client = SimpleActionClient(self.out_action_name, GripperCommandAction)
+        self.grasp_server.start()
+
+    def relay_action(self, goal: GraspGoal):
+        grasp_result = GraspResult()
+        gripper_goal = GripperCommandGoal()
+        gripper_goal.command.position = goal.width
+        gripper_goal.command.max_effort = goal.force
+
+        grasp_result.success = True
+        if not self.gripper_client.wait_for_server(rospy.Duration.from_sec(10)):
+            rospy.logerr(f"Timeout while waiting for {self.out_action_name}")
+            grasp_result.success = False
+            grasp_result.error = f"Timeout while waiting for {self.out_action_name}"
+
+        if not self.gripper_client.send_goal_and_wait(gripper_goal, rospy.Duration(10.0)):
+            rospy.logerr(f"Timeout while waiting for result from {self.out_action_name}")
+            grasp_result.success = False
+            grasp_result.error = f"Timeout while waiting for result from{self.out_action_name}"
+
+        if grasp_result.success:
+            self.grasp_server.set_succeeded(grasp_result)
+        else:
+            self.grasp_server.set_aborted(grasp_result)
+
+if __name__ == "__main__":
+    rospy.init_node("grasp_action_relay")
+    try:
+        relay = GraspRelay()
+        rospy.spin()
+    except rospy.ROSInterruptException:
+        pass

--- a/moma_gazebo/scripts/grasp_action_relay.py
+++ b/moma_gazebo/scripts/grasp_action_relay.py
@@ -6,13 +6,18 @@ from actionlib.simple_action_server import SimpleActionServer
 from franka_gripper.msg import GraspAction, GraspGoal, GraspResult
 from control_msgs.msg import GripperCommandAction, GripperCommandGoal
 
+
 class GraspRelay:
     def __init__(self) -> None:
         self.in_action_name = rospy.get_param("~in_action_name")
         self.out_action_name = rospy.get_param("~out_action_name")
 
-        self.grasp_server = SimpleActionServer(self.in_action_name, GraspAction, self.relay_action, auto_start=False)
-        self.gripper_client = SimpleActionClient(self.out_action_name, GripperCommandAction)
+        self.grasp_server = SimpleActionServer(
+            self.in_action_name, GraspAction, self.relay_action, auto_start=False
+        )
+        self.gripper_client = SimpleActionClient(
+            self.out_action_name, GripperCommandAction
+        )
         self.grasp_server.start()
 
     def relay_action(self, goal: GraspGoal):
@@ -27,15 +32,22 @@ class GraspRelay:
             grasp_result.success = False
             grasp_result.error = f"Timeout while waiting for {self.out_action_name}"
 
-        if not self.gripper_client.send_goal_and_wait(gripper_goal, rospy.Duration(10.0)):
-            rospy.logerr(f"Timeout while waiting for result from {self.out_action_name}")
+        if not self.gripper_client.send_goal_and_wait(
+            gripper_goal, rospy.Duration(10.0)
+        ):
+            rospy.logerr(
+                f"Timeout while waiting for result from {self.out_action_name}"
+            )
             grasp_result.success = False
-            grasp_result.error = f"Timeout while waiting for result from{self.out_action_name}"
+            grasp_result.error = (
+                f"Timeout while waiting for result from{self.out_action_name}"
+            )
 
         if grasp_result.success:
             self.grasp_server.set_succeeded(grasp_result)
         else:
             self.grasp_server.set_aborted(grasp_result)
+
 
 if __name__ == "__main__":
     rospy.init_node("grasp_action_relay")

--- a/moma_mission/config/state_machine/piloting.yaml
+++ b/moma_mission/config/state_machine/piloting.yaml
@@ -98,7 +98,7 @@ WAYPOINT_FOLLOWING:
   tolerance_deg: 50
 
 DETECTION_DECISION:
-  default_outcome: Completed
+  default_outcome: Failure
 
 OBSERVATION_POSE:
   default_outcome: None

--- a/moma_mission/config/state_machine/piloting.yaml
+++ b/moma_mission/config/state_machine/piloting.yaml
@@ -18,9 +18,9 @@ OPEN_GRIPPER:
 
 CLOSE_GRIPPER:
   default_outcome: None
-  gripper_action_name: /panda/franka_gripper/gripper_action
+  gripper_action_name: /panda/franka_gripper/grasp
   position: 0.0
-  max_effort: 20
+  max_effort: 1.0
   tolerance: 0.1
   timeout: 10.0
 
@@ -132,7 +132,7 @@ MODEL_FIT_VALVE:
   feature_matcher_acceptance_ratio: 1000.0
   ransac_min_consensus: 1 #2   # must be > min_successful detections
 
-a:
+PLAN_MODEL_VALVE:
   default_outcome: None
 
   poses_topic: /valve_poses

--- a/moma_mission/config/state_machine/piloting.yaml
+++ b/moma_mission/config/state_machine/piloting.yaml
@@ -98,7 +98,7 @@ WAYPOINT_FOLLOWING:
   tolerance_deg: 50
 
 DETECTION_DECISION:
-  default_outcome: Failure
+  default_outcome: Completed
 
 OBSERVATION_POSE:
   default_outcome: None

--- a/moma_mission/demo/piloting.py
+++ b/moma_mission/demo/piloting.py
@@ -141,7 +141,7 @@ try:
         rospy.loginfo("Close gripper")
         state_machine.add(
             "CLOSE_GRIPPER",
-            GripperControl,
+            GripperGrasp,
             transitions={
                 "Completed": "MANIPULATE_VALVE",
                 "Failure": "MANIPULATE_VALVE",
@@ -158,7 +158,7 @@ try:
         rospy.loginfo("Open gripper")
         state_machine.add(
             "OPEN_GRIPPER",
-            GripperControl,
+            GripperGrasp,
             transitions={"Completed": "BACKOFF_VALVE", "Failure": "Failure"},
         )
 

--- a/moma_mission/src/moma_mission/missions/piloting/sequences.py
+++ b/moma_mission/src/moma_mission/missions/piloting/sequences.py
@@ -5,7 +5,7 @@ import smach_ros
 
 from moma_mission.core import StateMachineRos, StateRos
 from moma_mission.missions.piloting.states import *
-from moma_mission.states.gripper import GripperControl
+from moma_mission.states.gripper import GripperControl, GripperGrasp
 from moma_mission.states.manipulation import JointsConfigurationAction
 
 
@@ -14,7 +14,7 @@ def homing_sequence_factory():
     with homing_sequence:
         homing_sequence.add(
             "OPEN_GRIPPER",
-            GripperControl,
+            GripperGrasp,
             transitions={"Completed": "HOME_ROBOT", "Failure": "Failure"},
         )
 

--- a/moma_mission/src/moma_mission/states/gripper.py
+++ b/moma_mission/src/moma_mission/states/gripper.py
@@ -2,7 +2,12 @@ import rospy
 import actionlib
 from sensor_msgs.msg import JointState
 from std_msgs.msg import Float64
-from control_msgs.msg import GripperCommandAction, GripperCommandGoal
+from control_msgs.msg import (
+    GripperCommandAction,
+    GripperCommandGoal,
+    GripperCommandResult,
+)
+from franka_gripper.msg import GraspAction, GraspGoal, GraspResult
 
 from moma_mission.core import StateRos, StateRosControl
 

--- a/moma_mission/src/moma_mission/states/gripper.py
+++ b/moma_mission/src/moma_mission/states/gripper.py
@@ -9,7 +9,7 @@ from control_msgs.msg import (
 )
 from franka_gripper.msg import GraspAction, GraspGoal, GraspResult
 
-from moma_mission.core import StateRos, StateRosControl
+from moma_mission.core import StateRos
 
 
 class GripperPositionControlState(StateRos):

--- a/moma_mission/src/moma_mission/states/gripper.py
+++ b/moma_mission/src/moma_mission/states/gripper.py
@@ -67,12 +67,12 @@ class GripperUSB(StateRos):
         return "Completed"
 
 
-class GripperControl(StateRos):
+class GripperAction(StateRos):
     """
     This state controls the gripper through the GripperCommandAction
     """
 
-    def __init__(self, ns=""):
+    def __init__(self, ns="", action_type=GripperCommandAction):
         StateRos.__init__(self, ns=ns)
 
         self.position = self.get_scoped_param("position")
@@ -80,15 +80,24 @@ class GripperControl(StateRos):
         self.tolerance = self.get_scoped_param("tolerance")
         self.server_timeout = self.get_scoped_param("timeout")
 
-        self.gripper_cmd = GripperCommandGoal()
-
-        self.gripper_cmd.command.position = self.position
-        self.gripper_cmd.command.max_effort = self.max_effort
-
+        self.gripper_goal = None
         self.gripper_action_name = self.get_scoped_param("gripper_action_name")
         self.gripper_client = actionlib.SimpleActionClient(
-            self.gripper_action_name, GripperCommandAction
+            self.gripper_action_name, action_type
         )
+        self._set_goal()
+        self.success = False
+
+    def _set_goal(self):
+        raise NotImplementedError()
+
+    def _done_cb(self, status, result):
+        if status == actionlib.GoalStatus.SUCCEEDED:
+            self.success = True
+        self._process_result(result)
+
+    def _process_result(self, result):
+        pass
 
     def run(self):
         if not self.gripper_client.wait_for_server(rospy.Duration(self.server_timeout)):
@@ -99,46 +108,14 @@ class GripperControl(StateRos):
             )
             return "Failure"
 
-        # TODO(giuseppe) remove hack --> kinova takes time to switch to highlevel mode
-        rospy.sleep(1.0)
-        self.gripper_client.send_goal(self.gripper_cmd)
+        self.gripper_client.send_goal(self.gripper_goal, done_cb=self._done_cb)
         if not self.gripper_client.wait_for_result(rospy.Duration(self.server_timeout)):
             rospy.logerr(
                 "Timeout exceeded while waiting the gripper action to complete"
             )
             return "Failure"
 
-        rospy.loginfo(
-            f"Sending gripper command: pos={self.gripper_cmd.command.position}, max_eff={self.gripper_cmd.command.max_effort}"
-        )
-        result = self.gripper_client.get_result()
-        error = abs(result.position - self.position)
-        tolerance_met = error < self.tolerance
-
-        success = True
-        if result is None:
-            rospy.logerr("None received from the gripper server")
-            success = False
-        elif result.stalled and not tolerance_met:
-            rospy.logerr(
-                "Gripper stalled and not moving, position error {} is larger than tolerance".format(
-                    error
-                )
-            )
-            success = False
-        elif result.stalled and tolerance_met:
-            rospy.logerr(
-                "Gripper stalled and not moving, position error {} is smaller than tolerance".format(
-                    error
-                )
-            )
-            success = True
-        elif result.reached_goal:
-            rospy.loginfo("Gripper successfully reached the goal")
-            success = True
-
-        if success:
-            rospy.sleep(1.0)  # just for safety
+        if self.success:
             return "Completed"
         else:
             return "Failure"

--- a/moma_mission/src/moma_mission/states/path_visitor.py
+++ b/moma_mission/src/moma_mission/states/path_visitor.py
@@ -51,6 +51,13 @@ class PathVisitorState(StateRosControl):
             self._poses_msg,
             queue_size=1,
         )
+
+        self.pose_publisher = rospy.Publisher(
+            self.get_scoped_param("pose_topic", "/desired_pose"),
+            PoseStamped,
+            queue_size=1,
+        )
+
         self.path_publisher = rospy.Publisher(
             self.get_scoped_param("path_topic", "/desired_path"), Path, queue_size=1
         )

--- a/moma_robot/config/controllers.yaml
+++ b/moma_robot/config/controllers.yaml
@@ -219,7 +219,7 @@ path_admittance_ur_controller:
 cartesian_impedance_controller:
   type: moma_controllers/CartesianImpedanceController
   arm_id: panda
-  target_frame: tool_frame
+  tool_link: tool_frame
   joint_names:
     - panda_joint1
     - panda_joint2

--- a/moma_robot/config/controllers.yaml
+++ b/moma_robot/config/controllers.yaml
@@ -70,6 +70,7 @@ mpc_controller:
   arm_id: panda
 
   robot_name: "panda"
+  task_file: "$(find moma_ocs2)/config/mpc/task_panda.info"
   base_type: 0
   base_link: "tracking_camera_odom"
   tool_link: "tool_frame"
@@ -110,6 +111,7 @@ mpc_wholebody_controller:
   arm_id: panda
 
   robot_name: "panda"
+  task_file: "$(find moma_ocs2)/config/mpc/task_panda_wholebody.info"
   base_type: 1
   base_link: "tracking_camera_odom"
   tool_link: "tool_frame"

--- a/moma_robot/launch/robot_pc_panda.launch
+++ b/moma_robot/launch/robot_pc_panda.launch
@@ -29,13 +29,6 @@
   </group>
 
   <group ns="panda">
-      <group ns="mpc_controller">
-        <param name="task_file" value="$(find moma_ocs2)/config/mpc/task_panda.info"/>
-      </group>
-      <group ns="mpc_wholebody_controller">
-        <param name="task_file" value="$(find moma_ocs2)/config/mpc/task_panda_wholebody.info"/>
-      </group>
-
       <node name="franka_control" pkg="franka_control" type="franka_control_node" output="screen" required="true">
         <rosparam command="load" file="$(find moma_robot)/config/franka_control_node.yaml" />
         <param name="robot_ip" value="$(arg robot_ip)" />

--- a/moma_robot/launch/robot_pc_smb.launch
+++ b/moma_robot/launch/robot_pc_smb.launch
@@ -9,6 +9,7 @@
         <arg name="simulation"              value="false"/>
         <arg name="mpc"                     value="false"/>
         <arg name="publish_robot_state"     value="false"/>  <!-- Since we do this in the current launch for the full robot -->
+        <arg name="setup"                   value="smb_piloting_properties"/>
     </include>
 
     <!-- Sensors -->
@@ -21,7 +22,9 @@
     <!-- Publish base odometry from tracking cam odometry measurements -->
     <node pkg="odometry_conversion"
           type="odometry_conversion_node"
-          name="tracking_camera_odometry_conversion" output="screen"/>
+          name="tracking_camera_odometry_conversion" output="screen">
+      <param name="use_planar_motion" value="true"/>
+    </node>
 
     <!-- Low level smb controller -->
     <include file="$(find smb_lowlevel_controller)/launch/smb_lowlevel_controller.launch" ns="smb">


### PR DESCRIPTION
Consistently moves the task file from the .launch to the controller .yaml.

Also, f6e48d9366750a1b6bbd3d112ef65363be1cdf2e breaks the valve controller in sim.
With 9a1915f654ab00c6c8ee5eee7ec2ff95ebb8f925 it fixes it by moving the controller launch to the mission launch as well, though this is not very nice as the controller manager spawns it every time we run the mission.
As an alternative, we could only spawn the valve in `mission.launch` if non-sim, and leave the valve spawning in the `gazebo.launch` as before.