### PR TITLE
Enhance grasp score to avoid entangled valve turning configurations

### DIFF
--- a/moma_mission/config/state_machine/piloting.yaml
+++ b/moma_mission/config/state_machine/piloting.yaml
@@ -132,10 +132,11 @@ MODEL_FIT_VALVE:
   feature_matcher_acceptance_ratio: 1000.0
   ransac_min_consensus: 1 #2   # must be > min_successful detections
 
-a:
+PLAN_MODEL_VALVE:
   default_outcome: None
 
   poses_topic: /valve_poses
+  robot_base_frame: panda_link0
   turning_angle_deg: 120.0
 
 PLAN_URDF_VALVE:

--- a/moma_mission/src/moma_mission/missions/piloting/states.py
+++ b/moma_mission/src/moma_mission/missions/piloting/states.py
@@ -9,12 +9,9 @@ from nav_msgs.msg import Path
 from visualization_msgs.msg import Marker, MarkerArray
 from object_keypoints_ros.srv import KeypointsPerception, KeypointsPerceptionRequest
 
-from moma_mission.utils.transforms import se3_to_pose_ros
+from moma_mission.utils.transforms import se3_to_pose_ros, tf_to_se3
 from moma_mission.utils.trajectory import get_timed_path_to_target
 from moma_mission.utils.robot import Robot
-from moma_mission.utils.transforms import (
-    tf_to_se3,
-)
 from moma_mission.states.navigation import SingleNavGoalState
 from moma_mission.states.model_fit import ModelFitState
 

--- a/moma_mission/src/moma_mission/missions/piloting/valve_model_planner.py
+++ b/moma_mission/src/moma_mission/missions/piloting/valve_model_planner.py
@@ -104,7 +104,9 @@ class ValveModelPlanner:
 
         return z_score + x_score
 
-    def _get_valid_paths(self, grasps_start, grasps, angle_max=2 * np.pi):
+    def _get_valid_paths(
+        self, grasps_start, grasps, angle_max=2 * np.pi, inverted=False
+    ):
         """
         Get a list of valid paths
 
@@ -150,7 +152,14 @@ class ValveModelPlanner:
             # Thus it is important to average the final score
             # Note that the angle is always positive, independent of turning direction
             # to simplify evaluation and avoid taking abs() in comparisons
-            paths.append({"angle": angle, "score": score / len(poses), "poses": poses})
+            paths.append(
+                {
+                    "angle": angle,
+                    "score": score / len(poses),
+                    "inverted": inverted,
+                    "poses": poses,
+                }
+            )
 
         return paths
 
@@ -171,7 +180,12 @@ class ValveModelPlanner:
         grasps = list(filter(self._is_non_singular_grasp, grasps))
         grasps_start = filter(self._is_non_obstructed_grasp, grasps)
 
-        paths = self._get_valid_paths(grasps_start, grasps, angle_max)
+        paths = self._get_valid_paths(
+            grasps_start=grasps_start,
+            grasps=grasps,
+            angle_max=angle_max,
+            inverted=inverted,
+        )
         return paths
 
     def get_path(self, angle_max=2 * np.pi):

--- a/moma_mission/src/moma_mission/missions/piloting/valve_model_planner.py
+++ b/moma_mission/src/moma_mission/missions/piloting/valve_model_planner.py
@@ -10,6 +10,8 @@ from moma_mission.missions.piloting.valve_fitting import ValveModel
 class ValveModelPlanner:
     """
     Generate graps and paths given a valve model
+
+    @param robot_base_pose: pose of the robot base, should be in the same frame as valve_model
     """
 
     def __init__(self, valve_model=ValveModel(), robot_base_pose=None):
@@ -17,15 +19,9 @@ class ValveModelPlanner:
         self.robot_base_heading = None
 
         if robot_base_pose is not None:
-            assert robot_base_pose.header.frame_id == valve_model.frame
-            self.robot_base_heading = np.array(
-                [
-                    robot_base_pose.position.x,
-                    robot_base_pose.position.y,
-                    robot_base_pose.position.z,
-                ]
-            )
-            self.robot_base_heading /= np.linalg.norm(self.robot_base_heading)
+            # assert robot_base_pose.header.frame_id == valve_model.frame
+            self.robot_base_heading = robot_base_pose.rotation[:, 0]
+            # self.robot_base_heading /= np.linalg.norm(self.robot_base_heading)
 
     def _get_all_grasping_poses(self, inverted=False, samples=100):
         """

--- a/moma_mission/src/moma_mission/missions/piloting/valve_model_planner.py
+++ b/moma_mission/src/moma_mission/missions/piloting/valve_model_planner.py
@@ -20,8 +20,9 @@ class ValveModelPlanner:
 
         if robot_base_pose is not None:
             # assert robot_base_pose.header.frame_id == valve_model.frame
-            self.robot_base_heading = robot_base_pose.rotation[:, 0]
-            # self.robot_base_heading /= np.linalg.norm(self.robot_base_heading)
+            # self.robot_base_heading = robot_base_pose.rotation[:, 0]  # trivial approach
+            self.robot_base_heading = valve_model.center - robot_base_pose.translation
+            self.robot_base_heading /= np.linalg.norm(self.robot_base_heading)
 
     def _get_all_grasping_poses(self, inverted=False, samples=100):
         """


### PR DESCRIPTION
More considerations when calculating the grasp score.
Essentially, the x-vector of the grasp should be as much in alignment with the robot base vector as possible.