### PR TITLE
Migrate from old `franka_ros` dependency to official one

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -108,6 +108,7 @@ sudo apt-get install \
 	ros-$ROS_DISTRO-py-trees-ros \
 	ros-$ROS_DISTRO-rqt-py-trees \
 	ros-$ROS_DISTRO-libfranka \
+	ros-$ROS_DISTRO-franka-ros \
 	ros-$ROS_DISTRO-joint-state-publisher-gui \
 	ros-$ROS_DISTRO-ddynamic-reconfigure \
 	ros-$ROS_DISTRO-lms1xx \

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -109,6 +109,7 @@ sudo apt-get install \
 	ros-$ROS_DISTRO-rqt-py-trees \
 	ros-$ROS_DISTRO-libfranka \
 	ros-$ROS_DISTRO-franka-ros \
+	ros-$ROS_DISTRO-franka-description \
 	ros-$ROS_DISTRO-joint-state-publisher-gui \
 	ros-$ROS_DISTRO-ddynamic-reconfigure \
 	ros-$ROS_DISTRO-lms1xx \

--- a/moma_core.repos
+++ b/moma_core.repos
@@ -18,8 +18,3 @@ repositories:
     type: git
     url: git@github.com:roboticsgroup/roboticsgroup_gazebo_plugins.git
     version: 4d93ecd
-
-  franka_ros:
-    type: git
-    url: git@github.com:ethz-asl/franka_ros.git
-    version: 2a4253bb6c46b3935079a52bd1ebae912ba220fe

--- a/moma_demos/piloting_demo/launch/gazebo.launch
+++ b/moma_demos/piloting_demo/launch/gazebo.launch
@@ -12,7 +12,7 @@
   <env name="GAZEBO_MODEL_PATH" value="$(optenv GAZEBO_MODEL_PATH):$(find moma_gazebo)/models:$(find piloting_demo)/models"/>
 
   <!-- send the robot XML to param server -->
-  <param name="robot_description" command="$(find xacro)/xacro $(find moma_description)/urdf/superpanda.urdf.xacro use_nominal_extrinsics:=true use_fixed_realsense:=$(arg use_fixed_realsense)
+  <param name="robot_description" command="$(find xacro)/xacro $(find moma_description)/urdf/superpanda.urdf.xacro sim:=true use_nominal_extrinsics:=true use_fixed_realsense:=$(arg use_fixed_realsense)
     control_mode:=$(arg control_mode) tool:=$(arg tool)"/>
 
   <!-- Allow interoperability between sim and real robot (we cannot change topic name on sim gripper controller plugin) -->

--- a/moma_demos/piloting_demo/launch/sim.launch
+++ b/moma_demos/piloting_demo/launch/sim.launch
@@ -15,7 +15,7 @@
 
     <group ns="ocs2_mpc">
         <param name="robot_description_ocs2" command="$(find xacro)/xacro $(find moma_description)/urdf/superpanda.urdf.xacro
-            mpc_model:=true use_nominal_extrinsics:=true tool:='none'"/>
+            sim:=true mpc_model:=true use_nominal_extrinsics:=true tool:='none'"/>
         <param name="reference_frame" value="tracking_camera_odom"/>
     </group>
 

--- a/moma_description/urdf/panda.xacro
+++ b/moma_description/urdf/panda.xacro
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="panda">
-  <xacro:macro name="panda" params="connected_to:='' rpy:='0 0 0' xyz:='0 0 0' use_fixed_realsense:=false
+  <xacro:macro name="panda" params="connected_to:='' rpy:='0 0 0' xyz:='0 0 0' sim:=false use_fixed_realsense:=false
     tool:='panda_hand' wrist_camera_name:='wrist_camera'">
 
     <!-- panda arm  -->
-    <xacro:include filename="$(find franka_description)/robots/panda_arm.xacro"/>
+    <xacro:if value="${sim}">
+        <xacro:include filename="$(find franka_description)/robots/panda_gazebo.xacro"/>
+    </xacro:if>
+    <xacro:unless value="${sim}">
+        <xacro:include filename="$(find franka_description)/robots/panda_arm.xacro"/>
+    </xacro:unless>
     <xacro:panda_arm connected_to="${connected_to}" rpy="${rpy}" xyz="${xyz}"/>
 
     <!-- no tool frame -->

--- a/moma_description/urdf/panda.xacro
+++ b/moma_description/urdf/panda.xacro
@@ -4,12 +4,12 @@
     tool:='panda_hand' wrist_camera_name:='wrist_camera'">
 
     <!-- panda arm  -->
-    <xacro:if value="${sim}">
+    <!--xacro:if value="${sim}"-->
         <xacro:include filename="$(find franka_description)/robots/panda_gazebo.xacro"/>
-    </xacro:if>
+    <!--/xacro:if>
     <xacro:unless value="${sim}">
         <xacro:include filename="$(find franka_description)/robots/panda_arm.xacro"/>
-    </xacro:unless>
+    </xacro:unless-->
     <xacro:panda_arm connected_to="${connected_to}" rpy="${rpy}" xyz="${xyz}"/>
 
     <!-- no tool frame -->

--- a/moma_description/urdf/superpanda.urdf.xacro
+++ b/moma_description/urdf/superpanda.urdf.xacro
@@ -2,6 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="superpanda">
 
   <!-- Panda Arguments -->
+  <xacro:arg name="sim" default="false"/>
   <xacro:arg name="use_fixed_realsense" default="false"/>
   <xacro:arg name="tool" default="panda_hand"/>
   <xacro:arg name="control_mode" default='Position'/>
@@ -66,6 +67,7 @@
   <xacro:include filename="$(find moma_description)/urdf/panda.xacro"/>
   <xacro:panda
     connected_to="arm_mount_link"
+    sim="$(arg sim)"
     use_fixed_realsense="$(arg use_fixed_realsense)"
     wrist_camera_name="$(arg wrist_camera_name)"
     tool="$(arg tool)"/>

--- a/moma_gazebo/config/panda_controllers.yaml
+++ b/moma_gazebo/config/panda_controllers.yaml
@@ -145,19 +145,19 @@ mpc_controller:
 
   gains:
     panda_joint1:
-      { p: 500.0, i: 0.0, d: 150.0, i_clamp_min: -100.0, i_clamp_max: 100.0 }
+      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -100.0, i_clamp_max: 100.0 }
     panda_joint2:
-      { p: 500.0, i: 0.0, d: 150.0, i_clamp_min: -5.0, i_clamp_max: 5.0 }
+      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -5.0, i_clamp_max: 5.0 }
     panda_joint3:
-      { p: 500.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
+      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
     panda_joint4:
-      { p: 500.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
+      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
     panda_joint5:
-      { p: 500.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
+      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
     panda_joint6:
-      { p: 500.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
+      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
     panda_joint7:
-      { p: 500.0, i: 0.0, d: 150.0, i_clamp_min: -0.1, i_clamp_max: 0.1 }
+      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -0.1, i_clamp_max: 0.1 }
 
 mpc_wholebody_controller:
   type: moma_controllers/PandaMpcController
@@ -185,19 +185,19 @@ mpc_wholebody_controller:
 
   gains:
     panda_joint1:
-      { p: 500.0, i: 0.0, d: 150.0, i_clamp_min: -100.0, i_clamp_max: 100.0 }
+      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -100.0, i_clamp_max: 100.0 }
     panda_joint2:
-      { p: 500.0, i: 0.0, d: 150.0, i_clamp_min: -5.0, i_clamp_max: 5.0 }
+      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -5.0, i_clamp_max: 5.0 }
     panda_joint3:
-      { p: 500.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
+      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
     panda_joint4:
-      { p: 500.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
+      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
     panda_joint5:
-      { p: 500.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
+      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
     panda_joint6:
-      { p: 500.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
+      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
     panda_joint7:
-      { p: 500.0, i: 0.0, d: 150.0, i_clamp_min: -0.1, i_clamp_max: 0.1 }
+      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -0.1, i_clamp_max: 0.1 }
 
 path_passthrough_controller:
   type: moma_controllers/PathPassthroughController

--- a/moma_gazebo/config/panda_controllers.yaml
+++ b/moma_gazebo/config/panda_controllers.yaml
@@ -153,11 +153,29 @@ mpc_controller:
     panda_joint4:
       { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
     panda_joint5:
-      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
+      {
+        p: 20000.0,
+        i: 100.0,
+        d: 250.0,
+        i_clamp_min: -1000.0,
+        i_clamp_max: 1000.0,
+      }
     panda_joint6:
-      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
+      {
+        p: 20000.0,
+        i: 100.0,
+        d: 250.0,
+        i_clamp_min: -1000.0,
+        i_clamp_max: 1000.0,
+      }
     panda_joint7:
-      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -0.1, i_clamp_max: 0.1 }
+      {
+        p: 10000.0,
+        i: 100.0,
+        d: 250.0,
+        i_clamp_min: -1000.0,
+        i_clamp_max: 1000.0,
+      }
 
 mpc_wholebody_controller:
   type: moma_controllers/PandaMpcController
@@ -193,11 +211,29 @@ mpc_wholebody_controller:
     panda_joint4:
       { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
     panda_joint5:
-      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
+      {
+        p: 20000.0,
+        i: 100.0,
+        d: 250.0,
+        i_clamp_min: -1000.0,
+        i_clamp_max: 1000.0,
+      }
     panda_joint6:
-      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -1.0, i_clamp_max: 1.0 }
+      {
+        p: 20000.0,
+        i: 100.0,
+        d: 250.0,
+        i_clamp_min: -1000.0,
+        i_clamp_max: 1000.0,
+      }
     panda_joint7:
-      { p: 50000.0, i: 0.0, d: 150.0, i_clamp_min: -0.1, i_clamp_max: 0.1 }
+      {
+        p: 10000.0,
+        i: 100.0,
+        d: 250.0,
+        i_clamp_min: -1000.0,
+        i_clamp_max: 1000.0,
+      }
 
 path_passthrough_controller:
   type: moma_controllers/PathPassthroughController

--- a/moma_mission/config/state_machine/piloting.yaml
+++ b/moma_mission/config/state_machine/piloting.yaml
@@ -38,7 +38,7 @@ HOME_ROBOT:
       "effort_joint_trajectory_controller",
     ]
   joints_configurations:
-    - [0, -0.885, 0, -2.1, 0, 1.571, 0]
+    - [0, -0.885, 0, -2.1, 0, 1.571, 0.785]
 
 # hack to avoid self collision in the end
 HOME_ROBOT_FINAL:
@@ -55,7 +55,7 @@ HOME_ROBOT_FINAL:
       "effort_joint_trajectory_controller",
     ]
   joints_configurations:
-    - [-0.65, -0.885, 0, -2.1, 0, 1.571, 0]
+    - [-0.65, -0.885, 0, -2.1, 0, 1.571, 0.785]
 
 REACH_DETECTION_HOTSPOT_FAR:
   default_outcome: None


### PR DESCRIPTION
TODO:
- [x] The MPC pid gains need more tuning in sim. It oscillates quite heavily, even with very high gains.
--> Still a bit shaky
- [x] Sometimes the joint space controller in gazebo freaks out moving the robot to random positions in sim, but this is very
 sporadically
- [x] The `GRIPPER_OPEN` state is broken (gripper opens, but state never completes) in sim

On any running installation, you should remove the `franka_ros` out of your `catkin_ws`. Also do a `catkin clean franka_ros` and resource the ws.
Also, upgrade to `ros-noetic-franka-description` version `0.8.2-2`.