### PR TITLE
Add autorecovery for Panda

### DIFF
--- a/moma_robot/CMakeLists.txt
+++ b/moma_robot/CMakeLists.txt
@@ -6,3 +6,8 @@ find_package(catkin REQUIRED)
 catkin_package()
 
 include_directories()
+
+catkin_install_python(
+  PROGRAMS scripts/panda_autorecovery.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/moma_robot/launch/robot_pc_panda.launch
+++ b/moma_robot/launch/robot_pc_panda.launch
@@ -34,6 +34,8 @@
         <param name="robot_ip" value="$(arg robot_ip)" />
       </node>
 
+      <node name="panda_autorecovery" pkg="moma_robot" type="panda_autorecovery.py" output="screen"/>
+
       <!-- Launch franka gripper -->
       <include file="$(find franka_gripper)/launch/franka_gripper.launch" if="$(arg load_gripper)">
          <arg name="robot_ip" value="$(arg robot_ip)" />

--- a/moma_robot/scripts/panda_autorecovery.py
+++ b/moma_robot/scripts/panda_autorecovery.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import rospy
+from franka_msgs.msg import ErrorRecoveryActionGoal, FrankaState
+
+last_robot_mode = -1
+
+
+def FrankaStateCallback(msg: FrankaState):
+    global last_robot_mode
+    if msg.robot_mode != last_robot_mode:
+        rospy.loginfo(f"Robot mode changed to {msg.robot_mode}")
+    last_robot_mode = msg.robot_mode
+
+    if msg.robot_mode == FrankaState.ROBOT_MODE_REFLEX:
+        rospy.logwarn("Automatically recovering from reflex error")
+        goal = ErrorRecoveryActionGoal()
+        error_recovery_pub.publish(goal)
+
+
+# Init ros
+rospy.init_node("panda_autorecovery")
+
+error_recovery_pub = rospy.Publisher(
+    "franka_control/error_recovery/goal", ErrorRecoveryActionGoal, queue_size=1
+)
+rospy.Subscriber(
+    "franka_state_controller/franka_states",
+    FrankaState,
+    FrankaStateCallback,
+    queue_size=1,
+)
+
+rospy.spin()


### PR DESCRIPTION
Whenever a communications constraint reflex error occurs, the recovery action should be called and potentially running controllers should be restarted.