### PR TITLE
Add alternative way of obtaining CI test results

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,7 +106,7 @@ jobs:
         run: |
           export DISPLAY=:99
           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
-          docker run -t --network host -e DISPLAY -v /tmp/.X11-unix ${{ secrets.PILOTING_DOCKERHUB_USERNAME }}/noetic-dev:${{github.event.number}} /bin/bash -c "rostest piloting_demo mission.test || (rostest --text piloting_demo mission.test && false)"
+          docker run -t --network host -e DISPLAY -v /tmp/.X11-unix ${{ secrets.PILOTING_DOCKERHUB_USERNAME }}/noetic-dev:${{github.event.number}} /bin/bash -c "rostest piloting_demo mission.test"
 
 #  test:
 #    needs: build

--- a/moma_demos/piloting_demo/launch/mission.launch
+++ b/moma_demos/piloting_demo/launch/mission.launch
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="sim" default="false"/>
+  <arg name="delay" default="0"/>
 
   <!-- Load joint controller to publish the joint state under object namespace -->
   <group ns="valve" if="$(arg sim)">
@@ -30,7 +31,7 @@
   <!-- mission state machine -->
   <rosparam command="load" file="$(find moma_mission)/config/state_machine/piloting.yaml" subst_value="true"/>
   <rosparam command="load" file="$(find moma_mission)/config/state_machine/piloting_frames.yaml"/>
-  <node pkg="moma_mission" type="piloting.py" name="piloting_demo" output="screen" required="true">
+  <node pkg="moma_mission" type="piloting.py" name="piloting_demo" output="screen" required="true" launch-prefix="bash -c 'sleep $(arg delay); $0 $@' ">
     <param name="telemetry_odom_topic" value="/base_odom"/>
   </node>
 </launch>

--- a/moma_demos/piloting_demo/scripts/test.py
+++ b/moma_demos/piloting_demo/scripts/test.py
@@ -5,6 +5,7 @@ import unittest
 import rospy
 import rospkg
 import subprocess
+from std_msgs.msg import Int8
 
 
 class TestPilotingMission(unittest.TestCase):
@@ -16,19 +17,24 @@ class TestPilotingMission(unittest.TestCase):
         os.system(
             f"perl -i -0777 -pe 's/(IDLE:.*?default_outcome: ).*?\n/\\1ExecuteDummyPlan\n/s' {moma_mission_path}/config/state_machine/piloting.yaml"
         )
-        rospy.sleep(120)  # Wait for environment
-        p = subprocess.Popen(
-            ["roslaunch", "piloting_demo", "mission.launch", "sim:=true"],
-            stderr=subprocess.PIPE,
-        )
-        err = str(p.stderr.read())
-        p.communicate()
-        self.assertEquals("exit code" in err, False)
-        # https://github.com/ros/ros_comm/issues/919
-        self.assertEquals(p.returncode, 0)
+        result = rospy.wait_for_message("/piloting_mission", Int8)
+        self.assertEquals(result, 0)
+
+        # rospy.sleep(120)  # Wait for environment
+        # p = subprocess.Popen(
+        #     ["roslaunch", "piloting_demo", "mission.launch", "sim:=true"],
+        #     stderr=subprocess.PIPE,
+        # )
+        # err = str(p.stderr.read())
+        # p.communicate()
+        # self.assertEquals("exit code" in err, False)
+        # # https://github.com/ros/ros_comm/issues/919
+        # self.assertEquals(p.returncode, 0)
 
 
 if __name__ == "__main__":
     import rostest
+
+    rospy.init_node("piloting_demo_test")
 
     rostest.rosrun(PKG, "test_piloting_mission", TestPilotingMission)

--- a/moma_demos/piloting_demo/test/mission.test
+++ b/moma_demos/piloting_demo/test/mission.test
@@ -5,5 +5,10 @@
     <arg name="rviz" value="false" />
   </include>
 
+  <include file="$(find piloting_demo)/launch/mission.launch">
+    <arg name="sim" value="true"/>
+    <arg name="delay" value="20"/>
+  </include>
+
   <test test-name="piloting_mission" pkg="piloting_demo" type="test.py" time-limit="1800.0"/>
 </launch>

--- a/moma_mission/demo/piloting.py
+++ b/moma_mission/demo/piloting.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import sys
 import rospy
+from std_msgs.msg import Int8
 from moma_mission.core.state_ros import *
 from moma_mission.missions.piloting.states import *
 from moma_mission.missions.piloting.sequences import *
@@ -21,6 +22,9 @@ rospy.init_node("piloting_demo")
 Valve.init_from_ros()
 Frames.init_from_ros()
 Frames.print_summary()
+
+# Init test result feedback
+result_pub = rospy.Publisher("/piloting_mission", Int8, queue_size=1, latch=True)
 
 # Build the state machine
 state_machine = StateMachineRos(outcomes=["Success", "Failure"])
@@ -233,8 +237,14 @@ except Exception as exc:
 rospy.loginfo("\n\nRunning the mission state machine!\n\n")
 outcome = state_machine.execute()
 rospy.loginfo("Mission plan terminated with outcome {}.".format(outcome))
+result = Int8()
 if outcome != "Success":
+    result.data = 1
+    result_pub.publish(result)
+    rospy.sleep(10)
     sys.exit(1)
+result.data = 0
+result_pub.publish(result)
 sys.exit(0)
 
 # Wait for ctrl-c to stop the application


### PR DESCRIPTION
This is not as clean as the current solution, but avoids rerunning the pipeline in case an error occurred.
Avoid merge in all cases if a solution with the current framework is possible.