### PR TITLE
Migrate to python3 default shebang

### DIFF
--- a/moma_controllers/moma_cartesian_impedance_controller/cfg/compliance_param.cfg
+++ b/moma_controllers/moma_cartesian_impedance_controller/cfg/compliance_param.cfg
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 PACKAGE = "moma_cartesian_impedance_controller"
 
 from dynamic_reconfigure.parameter_generator_catkin import *

--- a/moma_controllers/moma_joint_space_controller/scripts/joint_trajectory_commander.py
+++ b/moma_controllers/moma_joint_space_controller/scripts/joint_trajectory_commander.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/moma_controllers/panda_mpc/scripts/interactive_target_relay.py
+++ b/moma_controllers/panda_mpc/scripts/interactive_target_relay.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import rospy
 from ocs2_msgs.msg import mpc_target_trajectories
 from nav_msgs.msg import Path

--- a/moma_demos/piloting_demo/scripts/test.py
+++ b/moma_demos/piloting_demo/scripts/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 PKG = "piloting_demo"
 import os
 import unittest

--- a/moma_gazebo/scripts/gazebo_smart_spawner.py
+++ b/moma_gazebo/scripts/gazebo_smart_spawner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import xacro

--- a/moma_gazebo/scripts/unpause_gazebo.py
+++ b/moma_gazebo/scripts/unpause_gazebo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import time
 import rospy

--- a/moma_mission/src/moma_mission/core/state_ros.py
+++ b/moma_mission/src/moma_mission/core/state_ros.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import smach
 import rospy
 import tf2_ros

--- a/moma_mission/src/moma_mission/missions/piloting/rcs_bridge.py
+++ b/moma_mission/src/moma_mission/missions/piloting/rcs_bridge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import yaml
 import threading

--- a/moma_mission/src/moma_mission/missions/piloting/sequences.py
+++ b/moma_mission/src/moma_mission/missions/piloting/sequences.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python
+#!/usr/bin/env python3
 import rospy
 import smach
 import smach_ros

--- a/moma_mission/src/moma_mission/missions/piloting/valve_fitting.py
+++ b/moma_mission/src/moma_mission/missions/piloting/valve_fitting.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 

--- a/moma_mission/src/moma_mission/states/manipulation.py
+++ b/moma_mission/src/moma_mission/states/manipulation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import rospy
 import actionlib

--- a/moma_mission/src/moma_mission/states/navigation.py
+++ b/moma_mission/src/moma_mission/states/navigation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from moma_mission.utils import ros
 import tf

--- a/moma_mission/src/moma_mission/utils/moveit.py
+++ b/moma_mission/src/moma_mission/utils/moveit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from moveit_msgs.msg import Constraints, OrientationConstraint
 from moveit_msgs.msg import MoveItErrorCodes
 import os

--- a/moma_mission/src/moma_mission/utils/transforms.py
+++ b/moma_mission/src/moma_mission/utils/transforms.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 import numpy as np
 import pinocchio as pin
 

--- a/moma_moveit_utils/scripts/home_robot.py
+++ b/moma_moveit_utils/scripts/home_robot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import rospy
 from std_srvs.srv import Empty
 from moma_moveit_utils import MoveItPlanner

--- a/moma_moveit_utils/src/moma_moveit_utils/moveit_utils.py
+++ b/moma_moveit_utils/src/moma_moveit_utils/moveit_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from moveit_msgs.msg import Constraints, OrientationConstraint
 from moveit_msgs.msg import MoveItErrorCodes

--- a/moma_tools/moma_guis/moma_controller_manager_gui/scripts/moma_controller_manager_gui
+++ b/moma_tools/moma_guis/moma_controller_manager_gui/scripts/moma_controller_manager_gui
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/moma_tools/moma_guis/moma_controller_manager_gui/src/moma_controller_manager_gui/controller_manager.py
+++ b/moma_tools/moma_guis/moma_controller_manager_gui/src/moma_controller_manager_gui/controller_manager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (C) 2013, Georgia Tech
 # Copyright (C) 2015, PAL Robotics S.L.
 #

--- a/moma_tools/moma_guis/moma_controller_manager_gui/src/moma_controller_manager_gui/update_combo.py
+++ b/moma_tools/moma_guis/moma_controller_manager_gui/src/moma_controller_manager_gui/update_combo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (C) 2014, PAL Robotics S.L.
 #

--- a/moma_tools/moma_guis/moma_joint_position_control_gui/scripts/moma_joint_position_control_gui
+++ b/moma_tools/moma_guis/moma_joint_position_control_gui/scripts/moma_joint_position_control_gui
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/moma_tools/moma_guis/moma_joint_position_control_gui/src/moma_joint_position_control_gui/position_control.py
+++ b/moma_tools/moma_guis/moma_joint_position_control_gui/src/moma_joint_position_control_gui/position_control.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import rospy

--- a/moma_tools/moma_guis/moma_joint_states_display_gui/scripts/moma_joint_states_display_gui
+++ b/moma_tools/moma_guis/moma_joint_states_display_gui/scripts/moma_joint_states_display_gui
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/moma_tools/moma_guis/moma_joint_states_display_gui/src/moma_joint_states_display_gui/joint_states.py
+++ b/moma_tools/moma_guis/moma_joint_states_display_gui/src/moma_joint_states_display_gui/joint_states.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import rospy

--- a/moma_tools/moma_guis/moma_joint_velocity_control_gui/scripts/moma_joint_velocity_control_gui
+++ b/moma_tools/moma_guis/moma_joint_velocity_control_gui/scripts/moma_joint_velocity_control_gui
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/moma_tools/moma_guis/moma_joint_velocity_control_gui/src/moma_joint_velocity_control_gui/velocity_control.py
+++ b/moma_tools/moma_guis/moma_joint_velocity_control_gui/src/moma_joint_velocity_control_gui/velocity_control.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import rospy


### PR DESCRIPTION
Add more robustness to different runtime environments independent of the default `python` definition.