### PR TITLE
Add multi-object support to report generation

### DIFF
--- a/moma_demos/piloting_demo/scripts/report_generation.py
+++ b/moma_demos/piloting_demo/scripts/report_generation.py
@@ -135,7 +135,7 @@ class ReportGenerator:
                         previous_object_time = t
                     else:
                         print(
-                            f"[Report Generation]: Skipping object at time {t} as it is likely a duplicate of {previous_object_time}"
+                            f"[Report Generation]: Skipping object at time {t} as it is likely a duplicate of time {previous_object_time}"
                         )
                 for tf_message in message.transforms:
                     if topic == "/tf_static":

--- a/moma_demos/piloting_demo/scripts/report_generation.py
+++ b/moma_demos/piloting_demo/scripts/report_generation.py
@@ -561,6 +561,11 @@ class ReportGenerator:
 
                     # Save the image as well
                     cv2_img = bridge.imgmsg_to_cv2(message, "rgb8")
+                    # Enforce the image size to match the metadata in config
+                    cv2_img = cv2.resize(
+                        cv2_img,
+                        (CAMERA_IMAGE_SIZE["width"], CAMERA_IMAGE_SIZE["height"]),
+                    )
                     cv2.imwrite(
                         os.path.join(self.report_dir, "pictures", meta[0]), cv2_img
                     )

--- a/moma_demos/piloting_demo/scripts/report_generation.py
+++ b/moma_demos/piloting_demo/scripts/report_generation.py
@@ -26,8 +26,9 @@ SYNC_ID_TOPIC = "/sync_id"
 MAP_FRAME = "map"  # For local navigation: "tracking_camera_odom"
 OBJECT_TYPE = "valve"
 OBJECT_FRAME = "valve_wheel_center"
-IMAGE_TOPIC = "/object_keypoints_ros/result_img"
-IMAGES_DELTA_TIME = 5  # take a picture each 10 seconds
+OBJECT_IMAGE_TOPIC = "/object_keypoints_ros/result_img"
+IMAGE_TOPIC = "/image"
+IMAGES_DELTA_TIME = 0  # take a picture every ... seconds
 BASE_LINK_FRAME = "base_link"
 ODOM_TOPIC = "/mavsdk_ros/local_position"
 ROBOT_UUID = "f09df66e-cc30-4e11-92e8-fa2f5d7d19e5"
@@ -472,7 +473,9 @@ class ReportGenerator:
             #         "obj_ref",
             #     ]
             # )
-            for topic, message, t in self.bag.read_messages(topics=IMAGE_TOPIC):
+            for topic, message, t in self.bag.read_messages(
+                topics=[IMAGE_TOPIC, OBJECT_IMAGE_TOPIC]
+            ):
                 if (t.to_sec() - t_prev) > IMAGES_DELTA_TIME:
                     t_prev = t.to_sec()
 
@@ -504,9 +507,7 @@ class ReportGenerator:
                         )
 
                     # object info
-                    obj_ref = self.get_obj_ref(
-                        t
-                    )  # TODO It can also be a manually taken image with 0 obj_ref
+                    obj_ref = self.get_obj_ref(t) if topic == OBJECT_IMAGE_TOPIC else 0
 
                     meta = (
                         [

--- a/moma_demos/piloting_demo/scripts/report_generation.py
+++ b/moma_demos/piloting_demo/scripts/report_generation.py
@@ -78,7 +78,7 @@ class ReportGenerator:
         )
         self.robot_uuid = ROBOT_UUID
         self.plan_uuid = None
-        self.task_uuids = {}
+        self.task_uuids = None
         self.sync_id = None
         self.inspection_type = "visual"  # visual, contact, TBD
         self.map_file = "map.pcd"
@@ -202,6 +202,8 @@ class ReportGenerator:
 
     def __init_uuids(self):
         print("[Report Generation]: Reading UUIDs.")
+        self.task_uuids = {}
+
         for topic, message, t in self.bag.read_messages(
             topics=[PLAN_UUID_TOPIC, TASK_UUID_TOPIC, SYNC_ID_TOPIC]
         ):

--- a/moma_mission/src/moma_mission/missions/piloting/states.py
+++ b/moma_mission/src/moma_mission/missions/piloting/states.py
@@ -647,7 +647,7 @@ class ValveManipulationModelState(StateRos):
             valve_planner.poses_to_ros(valve_planner.get_path_approach_poses(path))
         )
 
-        self.total_angle += path["angle"]
+        self.total_angle += path["angle_signed"]
         self._publish_angle()
 
         return "Completed"

--- a/moma_mission/src/moma_mission/missions/piloting/valve_model_planner.py
+++ b/moma_mission/src/moma_mission/missions/piloting/valve_model_planner.py
@@ -162,6 +162,7 @@ class ValveModelPlanner:
             paths.append(
                 {
                     "angle": angle,
+                    "angle_signed": angle if step > 0 else -angle,
                     "score": score / len(poses),
                     "inverted": inverted if step > 0 else not inverted,
                     "poses": poses,

--- a/moma_mission/src/moma_mission/missions/piloting/valve_model_planner.py
+++ b/moma_mission/src/moma_mission/missions/piloting/valve_model_planner.py
@@ -163,7 +163,7 @@ class ValveModelPlanner:
                 {
                     "angle": angle,
                     "score": score / len(poses),
-                    "inverted": inverted,
+                    "inverted": inverted if step > 0 else not inverted,
                     "poses": poses,
                 }
             )


### PR DESCRIPTION
Add ability for consecutive multi-object perception in report generation, removing any hard-coded single-object leftovers.
Also fallback to 0 `obj_ref` in case an image has no corresponding object.

This implements the updated specifications agreed on with other Piloting partners.