### PR TITLE
Fix valve planner heading if desired angle cannot be reached

### DIFF
--- a/moma_mission/demo/piloting.py
+++ b/moma_mission/demo/piloting.py
@@ -162,7 +162,7 @@ try:
                 StateRosDummy,
                 transitions={
                     "Completed": "HOMING_DETECTION",
-                    "Failure": "PLAN_URDF_VALVE",
+                    "Failure": "PLAN_URDF_VALVE" if standalone else "Failure",
                 },
                 constants={"get_next_pose": False, "continue_valve_fitting": False},
             )
@@ -225,12 +225,14 @@ try:
                 transitions={"Completed": "APPROACH_VALVE", "Failure": "Failure"},
             )
 
-            rospy.loginfo("Plan urdf valve")
-            valve_sequence.add(
-                "PLAN_URDF_VALVE",
-                ValveManipulationUrdfState,
-                transitions={"Completed": "APPROACH_VALVE", "Failure": "Failure"},
-            )
+            # URDF planner only works if valve urdf is published, i. e. in standalone mode
+            if standalone:
+                rospy.loginfo("Plan urdf valve")
+                valve_sequence.add(
+                    "PLAN_URDF_VALVE",
+                    ValveManipulationUrdfState,
+                    transitions={"Completed": "APPROACH_VALVE", "Failure": "Failure"},
+                )
 
             rospy.loginfo("Approach valve")
             valve_sequence.add(

--- a/moma_mission/src/moma_mission/missions/piloting/valve_model_planner.py
+++ b/moma_mission/src/moma_mission/missions/piloting/valve_model_planner.py
@@ -222,7 +222,7 @@ class ValveModelPlanner:
         if len(valid_paths) == 0:
             rospy.loginfo_throttle(
                 1.0,
-                "No path meets max angle specification, using the one with highest score among the longest ones",
+                "No path meets max angle specification, falling back to path with highest score among the longest ones",
             )
             # The prior sorting for "score" is required to pick the path with the better heading
             # max(): "If multiple items are maximal, the function returns the first one encountered"


### PR DESCRIPTION
The gripper heading during valve turning would in some cases point towards robot if the desired `angle_max` cannot be attained.

Fixed test case:

```
[INFO]: Finally fit valve with residual 0.003816884197210532
center = [ 0.90995865 -0.26192747  0.25145769]
axis 1 = [-0.54023639  0.74151929  0.39786151]
axis 2 = [-0.83774807 -0.42923702 -0.33754073]
depth = 0.004633117506173666
radius = 0.10195936456030182
spoke_radius = 0.01
num_spokes = 4

[INFO]: Robot base pose is   R =
 0.818299 -0.574793         0
 0.574793  0.818299         0
        0         0         1
  p =  0.410351 -0.621469    0.3265

angle_max=120 * np.pi / 180
```

Wrong results:
![Pose](https://user-images.githubusercontent.com/80681863/173092826-7e834900-2dfe-4733-ad1f-5ca328fc8039.png)
![Pose far](https://user-images.githubusercontent.com/80681863/173092944-262cad19-9260-4c3b-b82e-3fb5b1994450.png)
![Pose close](https://user-images.githubusercontent.com/80681863/173092962-8c19a7cb-e6fc-473d-ac7b-2239c45a8a7b.png)

