### PR TITLE
Fix build issues in piloting install scripts and CI pipeline, upgrade to `franka-description` 0.10.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ COPY moma_mission/requirements.txt ${CATKIN_WS}/src/moma/moma_mission/
 WORKDIR ${CATKIN_WS}/src
 RUN vcs import --recursive --input moma/moma_core.repos
 RUN vcs import --recursive --input moma/moma_piloting.repos
+# Fix recent versions of Ubuntu putting /opt/ros/noetic/lib/x86_64-linux-gnu/pkgconfig into PKG_CONFIG_PATH
+# and then pinocchio will have a non-existent include path when queried with "pkg-config --cflags pinocchio"
+ENV PKG_CONFIG_PATH=""
 RUN apt-get -qq update && apt-get -qq upgrade && DEBIAN_FRONTEND=noninteractive moma/install_dependencies.sh --control --piloting
 RUN rosdep update
 RUN rosdep install --from-paths . --ignore-src -r -y || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,6 @@ COPY moma_mission/requirements.txt ${CATKIN_WS}/src/moma/moma_mission/
 WORKDIR ${CATKIN_WS}/src
 RUN vcs import --recursive --input moma/moma_core.repos
 RUN vcs import --recursive --input moma/moma_piloting.repos
-# Fix recent versions of Ubuntu putting /opt/ros/noetic/lib/x86_64-linux-gnu/pkgconfig into PKG_CONFIG_PATH
-# and then pinocchio will have a non-existent include path when queried with "pkg-config --cflags pinocchio"
-ENV PKG_CONFIG_PATH=""
 RUN apt-get -qq update && apt-get -qq upgrade && DEBIAN_FRONTEND=noninteractive moma/install_dependencies.sh --control --piloting
 RUN rosdep update
 RUN rosdep install --from-paths . --ignore-src -r -y || true

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -88,7 +88,6 @@ install_pinocchio() {
     info "Previous pinocchio installation found at ${PINOCCHIO_INSTALL_PREFIX}"
   fi
 
-
   cat << EOF >> ~/.moma_bashrc
 export PATH=${PINOCCHIO_INSTALL_PREFIX}/bin:\$PATH
 export PKG_CONFIG_PATH=${PINOCCHIO_INSTALL_PREFIX_STR}/lib/pkgconfig:\$PKG_CONFIG_PATH

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -51,7 +51,7 @@ EOF
 
   cat << EOF >> ~/.moma_bashrc
 export PATH=/opt/openrobots/bin:\$PATH
-export PKG_CONFIG_PATH=/opt/openrobots/lib/pkgconfig:\$PKG_CONFIG_PATH
+#export PKG_CONFIG_PATH=/opt/openrobots/lib/pkgconfig:\$PKG_CONFIG_PATH
 export LD_LIBRARY_PATH=/opt/openrobots/lib:\$LD_LIBRARY_PATH
 export LIBRARY_PATH=/opt/openrobots/lib:\$LIBRARY_PATH
 export PYTHONPATH=/opt/openrobots/lib/python3.8/site-packages:\$PYTHONPATH
@@ -61,6 +61,7 @@ EOF
 
 install_pinocchio() {
   echo "Installing pinocchio"
+  apt-get purge -qq ros-$ROS_DISTRO-pinocchio
   source ~/.moma_bashrc
 
   mkdir -p ~/git
@@ -91,7 +92,7 @@ install_pinocchio() {
 
   cat << EOF >> ~/.moma_bashrc
 export PATH=${PINOCCHIO_INSTALL_PREFIX}/bin:\$PATH
-export PKG_CONFIG_PATH=${PINOCCHIO_INSTALL_PREFIX_STR}/lib/pkgconfig:\$PKG_CONFIG_PATH
+#export PKG_CONFIG_PATH=${PINOCCHIO_INSTALL_PREFIX_STR}/lib/pkgconfig:\$PKG_CONFIG_PATH
 export LD_LIBRARY_PATH=${PINOCCHIO_INSTALL_PREFIX_STR}/lib:\$LD_LIBRARY_PATH
 export LIBRARY_PATH=${PINOCCHIO_INSTALL_PREFIX_STR}/lib:\$LIBRARY_PATH
 export PYTHONPATH=\$PYTHONPATH:${PINOCCHIO_INSTALL_PREFIX_STR}/lib/python2.7/dist-packages:${PINOCCHIO_INSTALL_PREFIX_STR}/lib/python3/dist-packages

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -88,7 +88,6 @@ install_pinocchio() {
     cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PINOCCHIO_INSTALL_PREFIX} -DBUILD_WITH_COLLISION_SUPPORT=ON -DBUILD_PYTHON_INTERFACE=ON -DBUILD_TESTING=OFF || fail "Please resource ~/.moma_bashrc and restart the script"
     make -j4 || fail "Error building pinocchio"
 
-    mkdir install
     make install || fail "Error installing pinocchio"
   else
     info "Previous pinocchio installation found at ${PINOCCHIO_INSTALL_PREFIX}"

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -208,8 +208,8 @@ done
 
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
-info "Installing control dependencies  = ${INSTALL_CONTROL_DEPS}"
-info "Installing piloting dependencies  = ${INSTALL_PILOTING_DEPS}"
+info "Installing control dependencies = ${INSTALL_CONTROL_DEPS}"
+info "Installing piloting dependencies = ${INSTALL_PILOTING_DEPS}"
 
 
 if [ "$DISTRIB_RELEASE" == "20.04" ] && [ "$ROS_DISTRO" == "noetic" ]; then

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -52,6 +52,7 @@ EOF
   cat << EOF >> ~/.moma_bashrc
 export PATH=/opt/openrobots/bin:\$PATH
 #export PKG_CONFIG_PATH=/opt/openrobots/lib/pkgconfig:\$PKG_CONFIG_PATH
+export PKG_CONFIG_PATH=""
 export LD_LIBRARY_PATH=/opt/openrobots/lib:\$LD_LIBRARY_PATH
 export LIBRARY_PATH=/opt/openrobots/lib:\$LIBRARY_PATH
 export PYTHONPATH=/opt/openrobots/lib/python3.8/site-packages:\$PYTHONPATH
@@ -61,7 +62,7 @@ EOF
 
 install_pinocchio() {
   echo "Installing pinocchio"
-  apt-get purge -qq ros-$ROS_DISTRO-pinocchio
+  sudo apt-get purge -qq ros-$ROS_DISTRO-pinocchio
   source ~/.moma_bashrc
 
   mkdir -p ~/git
@@ -93,6 +94,7 @@ install_pinocchio() {
   cat << EOF >> ~/.moma_bashrc
 export PATH=${PINOCCHIO_INSTALL_PREFIX}/bin:\$PATH
 #export PKG_CONFIG_PATH=${PINOCCHIO_INSTALL_PREFIX_STR}/lib/pkgconfig:\$PKG_CONFIG_PATH
+export PKG_CONFIG_PATH=""
 export LD_LIBRARY_PATH=${PINOCCHIO_INSTALL_PREFIX_STR}/lib:\$LD_LIBRARY_PATH
 export LIBRARY_PATH=${PINOCCHIO_INSTALL_PREFIX_STR}/lib:\$LIBRARY_PATH
 export PYTHONPATH=\$PYTHONPATH:${PINOCCHIO_INSTALL_PREFIX_STR}/lib/python2.7/dist-packages:${PINOCCHIO_INSTALL_PREFIX_STR}/lib/python3/dist-packages

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -53,6 +53,7 @@ EOF
 export PATH=/opt/openrobots/bin:\$PATH
 export PKG_CONFIG_PATH=/opt/openrobots/lib/pkgconfig:\$PKG_CONFIG_PATH
 export LD_LIBRARY_PATH=/opt/openrobots/lib:\$LD_LIBRARY_PATH
+export LIBRARY_PATH=/opt/openrobots/lib:\$LIBRARY_PATH
 export PYTHONPATH=/opt/openrobots/lib/python3.8/site-packages:\$PYTHONPATH
 export CMAKE_PREFIX_PATH=/opt/openrobots:\$CMAKE_PREFIX_PATH
 EOF
@@ -92,6 +93,7 @@ install_pinocchio() {
 export PATH=${PINOCCHIO_INSTALL_PREFIX}/bin:\$PATH
 export PKG_CONFIG_PATH=${PINOCCHIO_INSTALL_PREFIX_STR}/lib/pkgconfig:\$PKG_CONFIG_PATH
 export LD_LIBRARY_PATH=${PINOCCHIO_INSTALL_PREFIX_STR}/lib:\$LD_LIBRARY_PATH
+export LIBRARY_PATH=${PINOCCHIO_INSTALL_PREFIX_STR}/lib:\$LIBRARY_PATH
 export PYTHONPATH=\$PYTHONPATH:${PINOCCHIO_INSTALL_PREFIX_STR}/lib/python2.7/dist-packages:${PINOCCHIO_INSTALL_PREFIX_STR}/lib/python3/dist-packages
 export CMAKE_PREFIX_PATH=${PINOCCHIO_INSTALL_PREFIX_STR}:\$CMAKE_PREFIX_PATH
 EOF

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -51,8 +51,7 @@ EOF
 
   cat << EOF >> ~/.moma_bashrc
 export PATH=/opt/openrobots/bin:\$PATH
-#export PKG_CONFIG_PATH=/opt/openrobots/lib/pkgconfig:\$PKG_CONFIG_PATH
-export PKG_CONFIG_PATH=""
+export PKG_CONFIG_PATH=/opt/openrobots/lib/pkgconfig:\$PKG_CONFIG_PATH
 export LD_LIBRARY_PATH=/opt/openrobots/lib:\$LD_LIBRARY_PATH
 export LIBRARY_PATH=/opt/openrobots/lib:\$LIBRARY_PATH
 export PYTHONPATH=/opt/openrobots/lib/python3.8/site-packages:\$PYTHONPATH
@@ -63,6 +62,10 @@ EOF
 install_pinocchio() {
   echo "Installing pinocchio"
   sudo apt-get purge -qq ros-$ROS_DISTRO-pinocchio
+  # Bug in ROS build, this directory needs to exist
+  # Fix recent versions of Ubuntu putting /opt/ros/noetic/lib/x86_64-linux-gnu/pkgconfig into PKG_CONFIG_PATH
+  # and then pinocchio will have a non-existent include path when queried with "pkg-config --cflags pinocchio"
+  sudo mkdir /opt/ros/noetic/lib/include
   source ~/.moma_bashrc
 
   mkdir -p ~/git
@@ -93,8 +96,7 @@ install_pinocchio() {
 
   cat << EOF >> ~/.moma_bashrc
 export PATH=${PINOCCHIO_INSTALL_PREFIX}/bin:\$PATH
-#export PKG_CONFIG_PATH=${PINOCCHIO_INSTALL_PREFIX_STR}/lib/pkgconfig:\$PKG_CONFIG_PATH
-export PKG_CONFIG_PATH=""
+export PKG_CONFIG_PATH=${PINOCCHIO_INSTALL_PREFIX_STR}/lib/pkgconfig:\$PKG_CONFIG_PATH
 export LD_LIBRARY_PATH=${PINOCCHIO_INSTALL_PREFIX_STR}/lib:\$LD_LIBRARY_PATH
 export LIBRARY_PATH=${PINOCCHIO_INSTALL_PREFIX_STR}/lib:\$LIBRARY_PATH
 export PYTHONPATH=\$PYTHONPATH:${PINOCCHIO_INSTALL_PREFIX_STR}/lib/python2.7/dist-packages:${PINOCCHIO_INSTALL_PREFIX_STR}/lib/python3/dist-packages

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -16,8 +16,8 @@ info() {
 }
 
 fail() {
-    echo ${RED}[STOPPING DUE TO ERROR] $1${NC} >&2
-    exit 1
+  echo ${RED}[STOPPING DUE TO ERROR] $1${NC} >&2
+  exit 1
 }
 
 install_ci() {
@@ -75,17 +75,17 @@ install_pinocchio() {
   # If no previous install is found build the package again
   if [[ ! -d install ]]
   then
-      [ ! -d build ] || rm -r build
-      mkdir build
-      cd build
+    [ ! -d build ] || rm -r build
+    mkdir build
+    cd build
 
-      cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PINOCCHIO_INSTALL_PREFIX} -DBUILD_WITH_COLLISION_SUPPORT=ON -DBUILD_PYTHON_INTERFACE=ON -DBUILD_TESTING=OFF || fail "Please resource ~/.moma_bashrc and restart the script"
-      make -j4 || fail "Error building pinocchio"
+    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PINOCCHIO_INSTALL_PREFIX} -DBUILD_WITH_COLLISION_SUPPORT=ON -DBUILD_PYTHON_INTERFACE=ON -DBUILD_TESTING=OFF || fail "Please resource ~/.moma_bashrc and restart the script"
+    make -j4 || fail "Error building pinocchio"
 
-      mkdir install
-      make install || fail "Error installing pinocchio"
+    mkdir install
+    make install || fail "Error installing pinocchio"
   else
-    info "Previos pinocchio installation found at ${PINOCCHIO_INSTALL_PREFIX}"
+    info "Previous pinocchio installation found at ${PINOCCHIO_INSTALL_PREFIX}"
   fi
 
 
@@ -214,7 +214,7 @@ info "Installing piloting dependencies  = ${INSTALL_PILOTING_DEPS}"
 
 
 if [ "$DISTRIB_RELEASE" == "20.04" ] && [ "$ROS_DISTRO" == "noetic" ]; then
-  echo "${GREEN}Supported distribution was found${NC}"
+  info "Supported distribution was found"
 else
   fail "Your distribution is currently not officially supported"
 fi

--- a/moma_description/urdf/panda.xacro
+++ b/moma_description/urdf/panda.xacro
@@ -5,12 +5,29 @@
 
     <!-- panda arm  -->
     <!--xacro:if value="${sim}"-->
-        <xacro:include filename="$(find franka_description)/robots/panda_gazebo.xacro"/>
+        <!-- Up until franka-description 0.9.x -->
+        <!--xacro:include filename="$(find franka_description)/robots/panda_gazebo.xacro"/-->
     <!--/xacro:if>
     <xacro:unless value="${sim}">
         <xacro:include filename="$(find franka_description)/robots/panda_arm.xacro"/>
     </xacro:unless-->
-    <xacro:panda_arm connected_to="${connected_to}" rpy="${rpy}" xyz="${xyz}"/>
+
+    <!-- Starting from franka-description 0.10.x -->
+    <xacro:include filename="$(find franka_description)/robots/common/utils.xacro" />
+    <xacro:include filename="$(find franka_description)/robots/common/franka_arm.xacro" />
+
+    <!-- Up until franka-description 0.9.x -->
+    <!--xacro:panda_arm connected_to="${connected_to}" rpy="${rpy}" xyz="${xyz}"/-->
+
+    <!-- Starting from franka-description 0.10.x -->
+    <xacro:franka_arm
+      arm_id="panda"
+      connected_to="${connected_to}"
+      xyz="${xyz}"
+      rpy="${rpy}"
+      safety_distance="0.03"
+      gazebo="true"
+      joint_limits="${xacro.load_yaml('$(find franka_description)/robots/panda/joint_limits.yaml')}"/>
 
     <!-- no tool frame -->
     <xacro:if value="${tool == 'none' or tool == 'panda_hand'}">


### PR DESCRIPTION
Also fixes the following

**`hpp-fcl` lib not in `LIBRARY_PATH` causing build errors in `ocs2_pinocchio_interface`. Interestingly, this used to work before as it was.**
- [x] `ros-noetic-pinocchio` is installed via apt-get by default, colliding with the custom built one
- [x] `pkg-config --cflags pinocchio` includes `-I/opt/ros/noetic/lib/x86_64-linux-gnu/pkgconfig/../../include` which is nonexistent and is then later on fetched by ROS doing `pkg_check_modules` in `ocs2_pinocchio_interface`
- [x] Clear `buildcache` to test if it still builds


**Franka Emika version incompatibility**
- [x] Panda description got updated by Franka, not backwards compatible :angry: `ros-noetic-franka-description (0.10.1-1focal.20220926.212146) over (0.9.0-1focal.20220331.222326)`
Thanks Franka for making versions on Ubuntu and the robot itself **not downgradable and breaking**. That's really awesome and the way you want to spend time on broken things after just doing a simple update.