### PR TITLE
Update ICP and depending libraries to fix long-running crashes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [projects/piloting]
 
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   linting:
     runs-on: ubuntu-latest

--- a/moma_controllers/moma_ocs2/src/MobileManipulatorDistanceVisualization.cpp
+++ b/moma_controllers/moma_ocs2/src/MobileManipulatorDistanceVisualization.cpp
@@ -36,7 +36,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ocs2_self_collision/PinocchioGeometryInterface.h>
 #include <ocs2_self_collision/loadStdVectorOfPair.h>
 #include <ocs2_self_collision_visualization/GeometryInterfaceVisualization.h>
+// clang-format off
 #include <moma_ocs2/MobileManipulatorInterface.h>
+// clang-format on
 
 #include <ros/package.h>
 #include <ros/ros.h>

--- a/moma_controllers/moma_ocs2/src/MobileManipulatorInterface.cpp
+++ b/moma_controllers/moma_ocs2/src/MobileManipulatorInterface.cpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // clang-format on
 
 #include "moma_ocs2/MobileManipulatorInterface.h"
+
 #include <ocs2_core/initialization/DefaultInitializer.h>
 #include <ocs2_core/misc/LoadData.h>
 #include <ocs2_core/soft_constraint/StateInputSoftConstraint.h>

--- a/moma_demos/piloting_demo/test/mission.test
+++ b/moma_demos/piloting_demo/test/mission.test
@@ -5,5 +5,5 @@
     <arg name="rviz" value="false" />
   </include>
 
-  <test test-name="piloting_mission" pkg="piloting_demo" type="test.py" time-limit="3600.0"/>
+  <test test-name="piloting_mission" pkg="piloting_demo" type="test.py" time-limit="5400.0"/>
 </launch>

--- a/moma_piloting.repos
+++ b/moma_piloting.repos
@@ -46,13 +46,13 @@ repositories:
 
   icp_localization:
     type: git
-    url: https://github.com/leggedrobotics/icp_localization.git
-    version: 801e4f75fe06532c0f5ab55a810b524d99aa9cfb
+    url: https://github.com/jk-ethz/icp_localization.git
+    version: 09a8267db8e5bc7a0e806179b63f44f3bff00991
 
   libpointmatcher:
     type: git
-    url: https://github.com/leggedrobotics/libpointmatcher
-    version: b264553fcad6f386d96d8ba7bb95ded4582102c7
+    url: https://github.com/jk-ethz/libpointmatcher.git
+    version: 596025b62ee82804a78e781bb5b30da7f33e5e5c
 
   libnabo:
     type: git

--- a/moma_piloting.repos
+++ b/moma_piloting.repos
@@ -47,7 +47,7 @@ repositories:
   icp_localization:
     type: git
     url: https://github.com/jk-ethz/icp_localization.git
-    version: 09a8267db8e5bc7a0e806179b63f44f3bff00991
+    version: 0f39a25d54dc66accbcd1fba93eaa5986c83a430
 
   libpointmatcher:
     type: git


### PR DESCRIPTION
This PR updates the ICP repository sources, fixing several issues with ICP, mainly crashes that occur when running it for a long timespan (> 1 h).
The crashes were very sporadic and unpredictable, making them hard to pinpoint and debug. ICP mostly ended up with the message

```
terminate called after throwing an instance of 'PointMatcher<float>::DataPoints::InvalidField'
  what():  Point cloud has 31872 points in features but 32256 points in descriptors
/icp_node died from signal 6
/icp_node left a core dump
```

![issue](https://user-images.githubusercontent.com/80681863/208865165-be35d81c-b281-45f0-8fb8-4919171b14cd.png)

This was particularly annoying since ICP not only had to be restarted, but also reinitialized with the current estimated pose of the robot. By that time, the state machine mostly had stopped working already since the TF tree was not connected anymore.

The PR also updates `libpointmatcher` which had other bugs fixed in upstream repositories not merged into the branch we were depending on, yet.

Related:
- [#492](https://github.com/ethz-asl/libpointmatcher/pull/492)
- [#14](https://github.com/leggedrobotics/icp_localization/issues/14)