### PR TITLE
Fix state machine crash on keypoint depth estimation error

### DIFF
--- a/moma_demos/piloting_demo/launch/mission.launch
+++ b/moma_demos/piloting_demo/launch/mission.launch
@@ -18,8 +18,8 @@
   <!-- valve model -->
   <include file="$(find piloting_demo)/launch/valve.launch" if="$(arg standalone)">
     <arg name="sim" value="$(arg sim)"/>
-    <arg name="x" value="2.0"/>
-    <arg name="y" value="2.0"/>
+    <arg name="x" value="1.25"/>
+    <arg name="y" value="1.25"/>
     <!-- arg name="z" value="0"/-->
   </include>
 

--- a/moma_mission/src/moma_mission/missions/piloting/states.py
+++ b/moma_mission/src/moma_mission/missions/piloting/states.py
@@ -437,7 +437,11 @@ class ModelFitValveState(StateRos):
             return False
 
         req = KeypointsPerceptionRequest()
-        res = self.perception_srv_client.call(req)
+        try:
+            res = self.perception_srv_client.call(req)
+        except Exception as e:
+            rospy.logerr(e)
+            return False
 
         if len(res.keypoints.poses) != self.num_spokes + 1:
             return False

--- a/moma_piloting.repos
+++ b/moma_piloting.repos
@@ -7,7 +7,7 @@ repositories:
   object_keypoints_ros:
     type: git
     url: git@github.com:ethz-asl/object_keypoints_ros.git
-    version: 780ad826ebd5c6b6f2436bd5c523c575645a63f3
+    version: 4862b6fae5df4f18cec0973f1844f79f1c10572f
 
   cartographer:
     type: git


### PR DESCRIPTION
This catches any exceptions thrown by `object_keypoints_ros` in the PILOTING state machine, most prominently any depth estimation errors.